### PR TITLE
merge refactored base QMs

### DIFF
--- a/aas2rto/exc.py
+++ b/aas2rto/exc.py
@@ -1,6 +1,10 @@
 # Exceptions
 
 
+class BadKafkaConfigError(Exception):
+    pass
+
+
 class MissingCoordinatesError(Exception):
     pass
 

--- a/aas2rto/lightcurve_compilers.py
+++ b/aas2rto/lightcurve_compilers.py
@@ -20,6 +20,21 @@ DEFAULT_BADQUAL_TAG = "badqual"
 DEFAULT_ULIMIT_TAG = "upperlim"
 
 
+def _check_is_target_data(
+    data, source_name="<unknown data source>", target_id="<unknown target_id>"
+):
+    if isinstance(data, TargetData):
+        return True
+    data_type = type(data)
+    msg = (
+        f"broker '{source_name}' data for {target_id}"
+        f"is type {data_type}, not TargetData"
+    )
+    logger.warning(msg)
+    warnings.warn(UserWarning(msg))
+    return False
+
+
 def prepare_ztf_data(
     ztf_data: TargetData,
     valid_tag=DEFAULT_VALID_TAG,
@@ -27,44 +42,93 @@ def prepare_ztf_data(
     ulimit_tag=DEFAULT_ULIMIT_TAG,
 ):
 
-    if isinstance(ztf_data, TargetData):
-        data_list = []
-        if ztf_data.detections is not None:
-            detections = ztf_data.detections.copy()
-            detections.loc[:, "tag"] = valid_tag
-            # data_list = [detections]
-            data_list.append(detections)
-        if ztf_data.badqual is not None:
-            badqual = ztf_data.badqual.copy()
-            badqual.loc[:, "tag"] = badqual_tag
-            data_list.append(badqual)
-        if ztf_data.non_detections is not None:
-            ulimits = ztf_data.non_detections.copy()
-            ulimits.loc[:, "tag"] = ulimit_tag
-            data_list.append(ulimits)
-        if len(data_list) > 0:
-            ztf_lc = pd.concat(data_list, ignore_index=True)
-        else:
-            ztf_lc = ztf_data.lightcurve
+    data_list = []
+    if ztf_data.detections is not None:
+        detections = ztf_data.detections.copy()
+        detections.loc[:, "tag"] = valid_tag
+        # data_list = [detections]
+        data_list.append(detections)
+    if ztf_data.badqual is not None:
+        badqual = ztf_data.badqual.copy()
+        badqual.loc[:, "tag"] = badqual_tag
+        data_list.append(badqual)
+    if ztf_data.non_detections is not None:
+        ulimits = ztf_data.non_detections.copy()
+        ulimits.loc[:, "tag"] = ulimit_tag
+        data_list.append(ulimits)
+
+    # Now combine what's available.
+    if len(data_list) > 0:
+        ztf_lc = pd.concat(data_list, ignore_index=True)
     else:
-        logger.warning(
-            f"in prepare_ztf_data: ztf_data should be type TargetData, not {type(ztf_data)}"
-        )
-        return ztf_data
+        ztf_lc = ztf_data.lightcurve
 
     ztf_lc["source"] = "ztf"
 
-    # fix column names here
-
+    # Fix column names here
     ztf_band_lookup = {1: "ztfg", 2: "ztfr", 3: "ztfi"}
-    ztf_colmap = {"magpsf": "mag", "sigmapsf": "magerr"}
+    ztf_colmap = {"magpsf": "mag", "sigmapsf": "magerr", "candid": "alert_id"}
 
+    # Rename the bands (eg. for sncosmo)
     ztf_lc.loc[:, "band"] = ztf_lc["fid"].map(ztf_band_lookup)
-    ztf_lc.sort_values("mjd", inplace=True)
     ztf_lc.rename(ztf_colmap, axis=1, inplace=True)
 
-    use_cols = "mjd mag magerr diffmaglim tag band source candid".split()
+    ztf_lc.sort_values("mjd", inplace=True)
+    use_cols = "mjd mag magerr diffmaglim tag band source alert_id".split()
     return ztf_lc[use_cols]
+
+
+def prepare_lsst_data(
+    lsst_data: TargetData,
+    valid_tag=DEFAULT_VALID_TAG,
+    badqual_tag=DEFAULT_BADQUAL_TAG,
+    ulimit_tag=DEFAULT_ULIMIT_TAG,
+):
+
+    data_list = []
+    if lsst_data.detections is not None:
+        detections = lsst_data.detections.copy()
+        detections.loc[:, "tag"] = valid_tag
+        # data_list = [detections]
+        data_list.append(detections)
+    if lsst_data.badqual is not None:
+        badqual = lsst_data.badqual.copy()
+        badqual.loc[:, "tag"] = badqual_tag
+        data_list.append(badqual)
+    if lsst_data.non_detections is not None:
+        ulimits = lsst_data.non_detections.copy()
+        ulimits.loc[:, "tag"] = ulimit_tag
+        data_list.append(ulimits)
+
+    # Now combine what's available
+    if len(data_list) > 0:
+        lsst_lc = pd.concat(data_list, ignore_index=True)
+    else:
+        lsst_lc = lsst_data.lightcurve.copy()
+        lsst_lc.loc[:, "tag"] = valid_tag
+
+    lsst_lc.loc[:, "source"] = "lsst"
+
+    # Convert fluxes into mags and get the upperlims
+    psfFlux_snr = lsst_lc["psfFlux"] / lsst_lc["psfFluxErr"]
+    lsst_lc.loc[:, "mag"] = -2.5 * np.log10(lsst_lc["psfFlux"]) + 31.4  # flux in nJy
+    lsst_lc.loc[:, "magerr"] = 1.09 / psfFlux_snr  # 2.5 / ln(10) ~ 1.09
+    if "sky" in lsst_lc:
+        lsst_lc.loc[:, "diffmaglim"] = -2.5 * np.log10(lsst_lc["sky"]) + 31.4
+    else:
+        lsst_lc.loc[:, "diffmaglim"] = 0.0
+
+    # Fix some column names
+    lsst_colmap = {"midpointMjdTai": "mjd", "diaSourceId": "alert_id"}
+    lsst_lc.rename(lsst_colmap, axis=1, inplace=True)
+
+    # Rename the bands
+    lsst_band_lookup = {b: f"lsst{b}" for b in "u g r i z y".split()}
+    lsst_lc.loc[:, "band"] = lsst_lc["band"].map(lsst_band_lookup)
+
+    lsst_lc.sort_values("mjd", inplace=True)
+    keep_cols = "mjd mag magerr diffmaglim tag band alert_id source".split()
+    return lsst_lc[keep_cols]
 
 
 def prepare_atlas_data(
@@ -79,6 +143,7 @@ def prepare_atlas_data(
 
     # atlas_df["snr"] = atlas_df["uJy"] / atlas_df["duJy"]
 
+    # Convert mags to fluxes for averaging.
     dm_snr = 2.5 / np.log(10.0)
     atlas_lc["snr"] = dm_snr / atlas_lc["dm"]
 
@@ -91,17 +156,20 @@ def prepare_atlas_data(
     atlas_lc.sort_values("mjd", inplace=True)
 
     if average_epochs:
+        # Array trick to group observations with are "close" (<rolling_window)
         mjd_group = (
             atlas_lc["mjd"] > atlas_lc["mjd"].shift() + rolling_window
         ).cumsum()
         atlas_lc["mjd_group"] = mjd_group
 
+        # For each group of observations, take the mean flux, weighted err.
         row_list = []
         for (mjd_id, f_id), group in atlas_lc.groupby(["mjd_group", "F"]):
-            group.drop(["Obs", "F"], inplace=True, axis=1)  # so can compute mean on it.
+            # Drop some string columns so we can average column-wise.
+            group.drop(["Obs", "F"], inplace=True, axis=1)
 
             row = group.mean()
-            row["F"] = f_id  # have to remove and re-add because can't ave. string.
+            row["F"] = f_id  # Have to re-add, we needed to drop it so the ave. worked.
             row["N_exp"] = len(group)
             if len(group) == 1:
                 row_list.append(row)
@@ -130,23 +198,24 @@ def prepare_atlas_data(
     atlas_lc.sort_values("mjd", inplace=True, ignore_index=True)
     atlas_lc.reset_index(drop=True, inplace=True)
 
-    # Set upper lim tag here
-    tag_data = np.full(len(atlas_lc), valid_tag, dtype="object")
+    atlas_lc["source"] = "atlas"
+
+    # Set upper lim tag here - if mag is fainter than lim, or mag is negative.
+    tag_data = np.full(len(atlas_lc), valid_tag, dtype="object")  # Default to valid.
     upperlim_mask = (atlas_lc["m"] > atlas_lc["mag5sig"]) | (atlas_lc["m"] < 0)
     tag_data[upperlim_mask] = ulimit_tag
+    atlas_lc.loc[:, "tag"] = pd.Series(tag_data)
+
+    # Fix other columns here - remap band columns (for eg. sncosmo)
+    atlas_band_lookup = {"o": "atlaso", "c": "atlasc"}
+    atlas_lc.loc[:, "band"] = atlas_lc["F"].map(atlas_band_lookup)
+    # with pd.option_context("mode.chained_assignment", None):
+    #     atlas_lc.loc[:, "jd"] = Time(atlas_lc["mjd"].values, format="mjd").jd
 
     # Fix column names here
-    atlas_lc["source"] = "atlas"
-    atlas_band_lookup = {"o": "atlaso", "c": "atlasc"}
     atlas_colmap = {"m": "mag", "dm": "magerr", "mag5sig": "diffmaglim"}
-
-    with pd.option_context("mode.chained_assignment", None):
-        atlas_lc.loc[:, "band"] = atlas_lc["F"].map(atlas_band_lookup)
-        atlas_lc.loc[:, "jd"] = Time(atlas_lc["mjd"].values, format="mjd").jd
-        atlas_lc.loc[:, "tag"] = pd.Series(tag_data)
-
     atlas_lc.rename(atlas_colmap, axis=1, inplace=True)
-    use_cols = "mjd jd mag magerr diffmaglim tag band N_exp source".split()
+    use_cols = "mjd mag magerr diffmaglim tag band N_exp source".split()
     return atlas_lc[use_cols]
 
 
@@ -216,7 +285,7 @@ class DefaultLightcurveCompiler:
     valid_tag = DEFAULT_VALID_TAG
     badqual_tag = DEFAULT_BADQUAL_TAG
     ulimit_tag = DEFAULT_ULIMIT_TAG
-    default_broker_priority = ("fink", "lasair", "alerce")
+    default_broker_priority = ("fink", "alerce", "lasair", "ampel", "antares")
 
     def __init__(
         self,
@@ -243,36 +312,59 @@ class DefaultLightcurveCompiler:
 
         target_id = target.target_id
 
+        ##===== Prepare ZTF data =====##
         # Select the best data from the ZTF brokers
-        ztf_data = target.target_data.get("ztf", None)
+        ztf_data = target.target_data.get("ztf", None)  # Probably never happens...
         if ztf_data is None:
             for broker in self.broker_priority:
                 source_name = f"{broker}_ztf"
                 broker_data = target.target_data.get(source_name, None)
                 if broker_data is None:
-                    continue
-                if not isinstance(broker_data, TargetData):
-                    msg = (
-                        f"broker '{source_name}' data for  {target_id}"
-                        f"is type {type(broker_data)}, not TargetData"
-                    )
-                    logger.warning(msg)
-                    warnings.warn(UserWarning(msg))
+                    continue  # try next favouite broker...
+                if not _check_is_target_data(
+                    broker_data, source_name=source_name, target_id=target_id
+                ):
                     continue
                 if broker_data.lightcurve is not None:
                     ztf_data = broker_data
                     break
 
+        # If it exists, format it nicely.
         if ztf_data is not None:
             try:
                 ztf_lc = prepare_ztf_data(ztf_data, **tags)
                 lightcurve_dfs.append(ztf_lc)
             except Exception as e:
                 logger.error(e)
-                msg = f"can't process ztf_source {broker}: {target.target_id}"
+                msg = f"can't process ztf source {broker}: {target.target_id}"
                 raise ValueError(msg)
 
-        # Get ATLAS data
+        ##===== Prepare the LSST data =====##
+        # Get best data from LSST brokers
+        lsst_data = target.target_data.get("lsst", None)  # Probably never happens...
+        if lsst_data is None:
+            for broker in self.broker_priority:
+                source_name = f"{broker}_lsst"
+                broker_data = target.target_data.get(source_name, None)
+                if broker_data is None:
+                    continue  # try next favourite broker...
+                if not _check_is_target_data(
+                    broker_data, source_name=source_name, target_id=target_id
+                ):
+                    continue
+                if broker_data.lightcurve is not None:
+                    lsst_data = broker_data
+
+        # If it exists, format it nicely (to match everything else)
+        if lsst_data is not None:
+            try:
+                lsst_lc = prepare_lsst_data(lsst_data, **tags)
+                lightcurve_dfs.append(lsst_lc)
+            except Exception as e:
+                logger.error(e)
+                msg = f"can't process lsst source {broker}"
+
+        ##===== Prepare the ATLAS data =====##
         atlas_data = target.target_data.get("atlas", None)
         if atlas_data is not None:
             atlas_lc = atlas_data.lightcurve
@@ -286,7 +378,7 @@ class DefaultLightcurveCompiler:
                 if not (len(atlas_df) == 0 or atlas_df.empty):
                     lightcurve_dfs.append(atlas_df)
 
-        # Get YSE data
+        ##===== Prepare the YSE data =====##
         yse_data = target.target_data.get("yse", None)
         if yse_data is not None:
             yse_lc = yse_data.lightcurve
@@ -300,6 +392,7 @@ class DefaultLightcurveCompiler:
                 if not (len(yse_df) == 0 or yse_df.empty):
                     lightcurve_dfs.append(yse_df)
 
+        ##===== Stitch it all together =====##
         compiled_lightcurve = None
         if len(lightcurve_dfs) > 0:
             compiled_lightcurve = pd.concat(lightcurve_dfs, ignore_index=True)

--- a/aas2rto/messaging/messaging_manager.py
+++ b/aas2rto/messaging/messaging_manager.py
@@ -1,7 +1,6 @@
 import time
 import traceback
 from logging import getLogger
-from typing import Dict
 
 from astropy.time import Time
 
@@ -25,7 +24,7 @@ class MessagingManager:
 
     def __init__(
         self,
-        messengers_config: Dict[str, Dict],
+        messengers_config: dict[str, dict],
         target_lookup: TargetLookup,
         path_manager: PathManager,
     ):

--- a/aas2rto/messaging/telegram_messenger.py
+++ b/aas2rto/messaging/telegram_messenger.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import time
 
@@ -7,7 +9,6 @@ import warnings
 import yaml
 from logging import getLogger
 from pathlib import Path
-from typing import Dict, List, Tuple
 
 from astropy.time import Time
 
@@ -135,10 +136,10 @@ class TelegramMessenger:
     def send_to_user(
         self,
         user,
-        texts: List[str] = None,
-        img_paths: List[Path] = None,
+        texts: list[str] = None,
+        img_paths: list[Path] = None,
         caption=None,
-    ) -> List:
+    ) -> list:
         texts = texts or []
         if isinstance(texts, str):
             texts = [texts]
@@ -213,10 +214,10 @@ class TelegramMessenger:
     def message_users(
         self,
         users=None,
-        texts: List[str] = None,
-        img_paths: List[Path] = None,
+        texts: list[str] = None,
+        img_paths: list[Path] = None,
         caption=None,
-    ) -> Tuple[List, List]:
+    ) -> tuple[list, list]:
         if isinstance(users, int):
             users = [users]
 

--- a/aas2rto/messaging/telegram_messenger.py
+++ b/aas2rto/messaging/telegram_messenger.py
@@ -253,6 +253,10 @@ class TelegramMessenger:
                     user, texts=texts, img_paths=img_paths_to_send, caption=caption
                 )
                 sent_messages.extend(sent)
+            except telegram.error.TimedOut as e:
+                msg = f"TimedOut error for user {user} ({user_label})"
+                warnings.warn(UserWarning(msg))
+                exceptions.append(msg)
             except Exception as e:
                 tr = traceback.format_exc()
                 msg = f"for user {user} ({user_label}):\n{tr}\n\n{e}\n\n"

--- a/aas2rto/modeling/modeling_manager.py
+++ b/aas2rto/modeling/modeling_manager.py
@@ -2,7 +2,7 @@ import warnings
 from dataclasses import dataclass
 from logging import getLogger
 from multiprocessing import Pool
-from typing import Any, Callable, List
+from typing import Any, Callable
 
 from astropy.time import Time
 
@@ -63,7 +63,7 @@ class ModelingManager:
         self.path_manager = path_manager
 
     def build_target_models(
-        self, modeling_functions: List[Callable], t_ref: Time = None
+        self, modeling_functions: list[Callable], t_ref: Time = None
     ):
 
         lazy = self.config["lazy_modeling"]

--- a/aas2rto/modeling/modeling_manager.py
+++ b/aas2rto/modeling/modeling_manager.py
@@ -74,6 +74,9 @@ class ModelingManager:
 
         for modeling_func in modeling_functions:
 
+            if modeling_func is None:
+                continue
+
             try:
                 model_key = modeling_func.__name__
             except AttributeError as e:

--- a/aas2rto/modeling/sncosmo_salt.py
+++ b/aas2rto/modeling/sncosmo_salt.py
@@ -97,7 +97,7 @@ class PickleableF99Dust(sncosmo.PropagationEffect):
         ebv = self._parameters[0]
 
         inv_wave = 1e4 / wave  # per micron
-        axav = F99.evaluate(inv_wave, Rv=self._r_v)
+        axav = F99().evaluate(inv_wave, Rv=self._r_v)
 
         av = self._r_v * ebv
         ext = np.power(10.0, -0.4 * axav * av)

--- a/aas2rto/observatory/observatory_manager.py
+++ b/aas2rto/observatory/observatory_manager.py
@@ -55,7 +55,6 @@ class ObservatoryManager:
         if not dt_unit.is_equivalent(u.s):
             raise u.UnitTypeError(f"{dt_unit} should be equiv. to 'u.s'")
         self.config["dt"] = self.config["dt"] * dt_unit
-        print(self.config["dt"])
 
     def init_observing_sites(self):
         self.sites: dict[str, Observer] = {}

--- a/aas2rto/observatory/observatory_manager.py
+++ b/aas2rto/observatory/observatory_manager.py
@@ -2,7 +2,6 @@ import copy
 import warnings
 from logging import getLogger
 from pathlib import Path
-from typing import Dict
 
 from astropy import units as u
 from astropy.coordinates import EarthLocation

--- a/aas2rto/outputs/outputs_manager.py
+++ b/aas2rto/outputs/outputs_manager.py
@@ -141,12 +141,31 @@ class OutputsManager:
             )
             self.obs_ranked_lists[obs_name] = ranked_list
 
+    def clear_plots_from_path(self, plots_path: Path, fmt: str = "png"):
+        removed = 0
+        try:
+            print_path = plots_path.relative_to(self.path_manager.project_path)
+        except Exception as e:
+            print_path = plots_path
+
+        logger.info(f"remove all '*.{fmt}' from {print_path}")
+        if plots_path.exists():
+            for plot in plots_path.glob(f"*.{fmt}"):
+                plot.unlink()
+                removed = removed + 1
+        logger.info(f"removed {removed} '{fmt}' plots")
+
     def rank_targets_on_science_score(
         self, plots: bool = False, write_list: bool = True, t_ref: Time = None
     ) -> pd.DataFrame:
         t_ref = t_ref or Time.now()
 
         plots_path = self.path_manager.get_output_plots_path("science_score")
+
+        if plots:
+            self.clear_plots_from_path(plots_path)
+        else:
+            logger.info("not clearing existing plots from outputs (as plots=False)")
 
         minimum_score = self.config["minimum_score"]
         unranked_value = self.config["unranked_value"]
@@ -196,6 +215,11 @@ class OutputsManager:
         obs_name = utils.get_observatory_name(observatory)
         list_name = f"obs_{obs_name}"
         plots_path = self.path_manager.get_output_plots_path(f"obs_{obs_name}")
+
+        if plots:
+            self.clear_plots_from_path(plots_path)
+        else:
+            logger.info("not clearing existing plots from outputs (as plots=False)")
 
         minimum_score = self.config["minimum_score"]
         unranked_value = self.config["unranked_value"]

--- a/aas2rto/outputs/outputs_manager.py
+++ b/aas2rto/outputs/outputs_manager.py
@@ -2,7 +2,6 @@ import shutil
 import warnings
 from logging import getLogger
 from pathlib import Path
-from typing import Dict, List
 
 import numpy as np
 
@@ -96,7 +95,7 @@ class OutputsManager:
 
     def write_target_comments(
         self,
-        target_list: List[Target] = None,
+        target_list: list[Target] = None,
         outdir: Path = None,
         t_ref: Time = None,
     ) -> None:

--- a/aas2rto/plotting/default_plotter.py
+++ b/aas2rto/plotting/default_plotter.py
@@ -4,7 +4,6 @@ import traceback
 import warnings
 from logging import getLogger
 from pathlib import Path
-from typing import Callable, Dict, List, Union
 
 import numpy as np
 

--- a/aas2rto/plotting/visibility_plotter.py
+++ b/aas2rto/plotting/visibility_plotter.py
@@ -254,6 +254,7 @@ class VisibilityPlotter:
                 loc="lower center",
                 bbox_to_anchor=(0.5, 1.01),
                 handles=self.legend_handles,
+                ncols=3,
             )
             self.alt_ax.add_artist(legend)
         if self.sky_ax is not None:

--- a/aas2rto/plotting/visibility_plotter.py
+++ b/aas2rto/plotting/visibility_plotter.py
@@ -4,7 +4,6 @@ import traceback
 import warnings
 from logging import getLogger
 from pathlib import Path
-from typing import Callable, Dict, List, Union
 
 import numpy as np
 

--- a/aas2rto/query_managers/base.py
+++ b/aas2rto/query_managers/base.py
@@ -11,13 +11,12 @@ import pandas as pd
 from astropy.table import Table
 from astropy.time import Time
 
+from aas2rto import paths
 from aas2rto.exc import UnknownTargetWarning
 from aas2rto.target import Target
 from aas2rto.target_data import TargetData
 from aas2rto.target_lookup import TargetLookup
-from aas2rto import paths
-
-from aas2rto import utils
+from aas2rto.utils import calc_file_age, clear_stale_files
 
 logger = getLogger("base_qm")
 
@@ -35,18 +34,38 @@ DEFAULT_DIRECTORIES = [
 
 
 class BaseQueryManager(abc.ABC):
+    """
+    The base class for all query managers.
+    Only implements abstract methods and some path-processing methods.
+    """
 
+    config: dict = None
     target_lookup: TargetLookup = None
 
     @property
     @abc.abstractmethod
     def name(self):
-        raise NotImplementedError
+        """Class attribute - the NAME of the query manager eg. 'atlas', 'fink_ztf', ..."""
 
     @abc.abstractmethod
-    def perform_all_tasks(self):
-        msg = f"query_manager {self.name}: implement a function which accepts kwargs:\n    startup:bool, t_ref=:astropy.time.Time"
-        raise NotImplementedError(msg)
+    def perform_all_tasks(self, iteration: int, t_ref: Time = None):
+        """perform_all_tasks(self, iteration: int, t_ref: Time=None)
+
+        The method that the TargetSelector will use to operate your QueryManager
+        Any methods the QM needs (outside of __init__) should be called here.
+
+        Parameters
+        ----------
+        iteration: int
+            `iteration` counter can optionally be used to modify behaviour of QM
+            eg. on iteration=0 (startup), FinkQMs do not make new queries, only load
+            existing data
+        """
+
+    def __init__(self, config: dict, target_lookup: TargetLookup, parent_path: Path):
+        self.config = config
+        self.target_lookup = target_lookup
+        self.parent_path = parent_path
 
     def process_paths(
         self,
@@ -60,16 +79,17 @@ class BaseQueryManager(abc.ABC):
 
         Parameters
         ----------
-        data_path : Path, default=None
-            where should data for this query manager be stored? often it's more
-            convenient to use parent_path (see below)
         parent_path : Path, default=None
             the parent directory of where QM data should be stored - the data_path
-            is then set as data_path = parent_path / cls.name (ie. using the name param
-            that you provided when defining the class!)
+            is then set as `data_path = parent_path / cls.name`
+            (ie. using the name param that you provided when defining the class!)
+        data_path : Path, default=None
+            where should data for this query manager be stored? often it's more
+            convenient to use parent_path (above)
         create_paths : bool, default=True
             actually create the directories
-        directories : list, default=`DEFAULT_DIRECTORIES`
+        directories : list
+            sub directories to create
         """
         if data_path is None:
             if parent_path is None:
@@ -109,21 +129,122 @@ class BaseQueryManager(abc.ABC):
         for dir_name, path in self.paths_lookup.items():
             path.mkdir(exist_ok=True)
 
+    def clear_stale_files(
+        self, stale_age=60.0, max_depth=3, dry_run=False, t_ref: Time = None
+    ):
+        """
+        Clear files/directories older than eg. 60 days.
+
+        stale_time
+            how many days to check
+
+        """
+
+        t_ref = t_ref or Time.now()
+
+        for dir_name, top_level_dir in self.paths_lookup.items():
+            N_dirs, N_files = clear_stale_files(
+                top_level_dir, t_ref=t_ref, stale_age=stale_age, max_depth=max_depth
+            )
+            if N_dirs > 0 or N_files > 0:
+                logger.info(
+                    f"Removing stale files in {dir_name}:\n    "
+                    f"del {N_files} files >{stale_age:.1f}d old, {N_dirs} empty subdirs"
+                )
+
+
+class LightcurveQueryManager(BaseQueryManager, abc.ABC):
+    """
+    A base class for query managers that are primarily used for querying lightcurves
+
+    """
+
+    DEFAULT_LIGHTCURVE_UPDATE_INTERVAL = 2.0
+
+    @property
+    @abc.abstractmethod
+    def id_resolving_order(self) -> tuple[str]:
+        """tuple of strings.
+        what order should we look for the relevant id in target.alt_ids?
+
+        eg1. for FinkZTDQueryManager, id_resolving_order = ("fink_ztf", "ztf")
+
+        If there is a specific name that FINK uses for this ZTF target by (unlikely...),
+        take that first. Then, if there's a 'generic' ZTF name, take that. Otherwise,
+        it's not a target known in the ZTF survey.
+
+        eg2. for YSEQueryManager, id_resolving_order = ("tns", "yse")
+
+        Even if the object has a YSE name, the YSE servers still prefer the TNS name."""
+
+    @abc.abstractmethod
     def load_single_lightcurve(
         self, target_id: str, t_ref: Time = None
     ) -> pd.DataFrame | Table:
-        # NOT an @abc.abstractmethod, as some QMs that do not have LCs will
-        # not implement (eg. TNS)
-        logger.error(
-            f"{self.name}: to call load_target_lightcurves, must implement load_single_lightcurve"
+        """load_single_lightcurve(self, target_id: str, t_ref: Time=None)
+
+        return pd.DataFrame OR astropy.table.Table
+        """
+
+    @abc.abstractmethod
+    def get_lightcurve_filepath(self, id_: str):
+        """get_lightcurve_filepath(self, idd: str)
+
+        return the path of a lightcurve which should be under name 'id_'
+        You should use a more sensible variable name for id_ in subclasses
+        (eg. fink_id, atlas_id...)
+        """
+
+    def get_relevant_id_from_target(self, target: Target):
+        """Loop over self.id_resolving_order, return the first value from key
+        found in target.alt_ids
+
+        For example: if FinkQM.id_resolving_order = ("fink", "fink_ztf", "tns")
+        and target.alt_ids = {"fink_ztf": "ZTFabc", "other_srv": "T001"}
+        would return "ZTFabc"
+        """
+
+        for alt_key in self.id_resolving_order:
+            relevant_id = target.alt_ids.get(alt_key, None)
+            if relevant_id is not None:
+                return relevant_id
+        return None
+
+    def select_lightcurves_to_query(self, t_ref: Time = None):
+        """
+        Which lightcurves should be re-queried?
+
+        Check the age of each file.
+        """
+
+        t_ref = t_ref or Time.now()
+
+        to_query = []
+        no_relevant_id = []
+        max_age = self.config.get(
+            "lightcurve_update_interval", self.DEFAULT_LIGHTCURVE_UPDATE_INTERVAL
         )
-        msg = f"QueryManager for {self.name}: load_single_lightcurve() not implemented"
-        raise NotImplementedError(msg)
+        for target_id, target in self.target_lookup.items():
+            relevant_id = self.get_relevant_id_from_target(target)
+            if relevant_id is None:
+                no_relevant_id.append(target_id)
+                continue  # There is no relevant ID to ask FINK for lightcurve
+            lightcurve_filepath = self.get_lightcurve_filepath(relevant_id)
+            lc_age = calc_file_age(lightcurve_filepath, t_ref=t_ref)
+            if lc_age > max_age:
+                to_query.append(relevant_id)
+        msg = f"LCs for {len(to_query)} targets need updating (age > {max_age:.1f}d or missing)"
+        logger.info(msg)
+        if len(no_relevant_id) > 0:
+            logger.info(
+                f"({len(no_relevant_id)} have no relevant id for '{self.name}')"
+            )
+        return to_query
 
     def load_target_lightcurves(
         self,
         id_list: List[str] = None,
-        only_flag_updated=True,
+        only_flag_updated: bool = True,
         t_ref: Time = None,
     ):
         """
@@ -177,7 +298,7 @@ class BaseQueryManager(abc.ABC):
             except Exception as e:
                 pass
 
-            qm_data = target.get_target_data(self.name)
+            qm_data = target.get_target_data(self.name)  # returns empty TD() if missing
             # get eg. target.target_data["fink_ztf"], target.target_data["yse"], ...
 
             existing_lightcurve = qm_data.lightcurve
@@ -205,25 +326,63 @@ class BaseQueryManager(abc.ABC):
         logger.info(msg)
         return loaded, skipped, missing
 
-    def clear_stale_files(
-        self, stale_age=60.0, max_depth=3, dry_run=False, t_ref: Time = None
-    ):
-        """
-        Clear files/directories older than eg. 60 days.
 
-        stale_time
-            how many days to check
+class KafkaQueryManager(BaseQueryManager, abc.ABC):
+    """Used for adding targets that receive data from Kafka streams"""
 
-        """
+    @property
+    @abc.abstractmethod
+    def target_id_key() -> str:
+        """how do the alerts refer to targets?
 
+        eg. `FinkZTFQueryManager` has `target_id_key='objectId', ``"""
+
+    @abc.abstractmethod
+    def listen_for_alerts(self) -> list[dict]:
+        """listen_for_alerts(self)
+
+        return a list of processed alerts. Each alert should contain at LEAST the value
+        defined by `target_id_key`.
+
+        eg. `FinkZTFQueryManager` has `target_id_key='objectId'`,
+        so all processed_alerts must contain `objectId`"""
+
+    @abc.abstractmethod
+    def new_target_from_alert(
+        self, processed_alert: dict, t_ref: Time = None
+    ) -> Target:
+        """new_target_from_alert(self, processed_alert: dict, t_ref: Time=None)
+
+        return a target, based"""
+
+    def add_targets_from_alerts(
+        self, processed_alerts: list[dict], t_ref: Time = None
+    ) -> list[str]:
         t_ref = t_ref or Time.now()
 
-        for dir_name, top_level_dir in self.paths_lookup.items():
-            N_dirs, N_files = utils.clear_stale_files(
-                top_level_dir, t_ref=t_ref, stale_age=stale_age, max_depth=max_depth
-            )
-            if N_dirs > 0 or N_files > 0:
-                logger.info(
-                    f"Removing stale files in {dir_name}:\n    "
-                    f"del {N_files} files >{stale_age:.1f}d old, {N_dirs} empty subdirs"
+        targets_added = []
+        existing_skipped = []
+        for alert in processed_alerts:
+            target_id = alert[self.target_id_key]
+
+            ##== Do we already know about it?
+            existing_target = self.target_lookup.get(target_id, None)
+            if existing_target is not None:
+                existing_skipped.append(target_id)
+                continue
+
+            ##== Otherwise add it...
+            target = self.new_target_from_alert(alert, t_ref=t_ref)
+            if not isinstance(target, Target):
+                msg = (
+                    f"implementation of {self.__class__}.new_target_from_alert"
+                    " should return Target"
                 )
+                raise TypeError()
+            self.target_lookup.add_target(target)
+            targets_added.append(target.target_id)
+
+        N_added = len(targets_added)
+        N_skipped = len(existing_skipped)
+        logger.info(f"added {N_added} new targets (skipped {N_skipped} existing)")
+        return targets_added

--- a/aas2rto/query_managers/base.py
+++ b/aas2rto/query_managers/base.py
@@ -109,7 +109,11 @@ class BaseQueryManager(abc.ABC):
         for dir_name, path in self.paths_lookup.items():
             path.mkdir(exist_ok=True)
 
-    def load_single_lightcurve(self, target_id: str, t_ref: Time = None):
+    def load_single_lightcurve(
+        self, target_id: str, t_ref: Time = None
+    ) -> pd.DataFrame | Table:
+        # NOT an @abc.abstractmethod, as some QMs that do not have LCs will
+        # not implement (eg. TNS)
         logger.error(
             f"{self.name}: to call load_target_lightcurves, must implement load_single_lightcurve"
         )

--- a/aas2rto/query_managers/base.py
+++ b/aas2rto/query_managers/base.py
@@ -1,8 +1,9 @@
+from __future__ import annotations  # Must come first
+
 import abc
 import time
 import warnings
 from logging import getLogger
-from typing import Callable, Dict, List
 
 from pathlib import Path
 
@@ -114,7 +115,7 @@ class BaseQueryManager(abc.ABC):
         if isinstance(extra_directories, str):
             extra_directories = [extra_directories]
 
-        self.paths_lookup: Dict[str, Path] = {}
+        self.paths_lookup: dict[str, Path] = {}
         for dir_name in list(directories) + list(extra_directories):
             path = self.data_path / dir_name
             self.paths_lookup[dir_name] = path
@@ -243,7 +244,7 @@ class LightcurveQueryManager(BaseQueryManager, abc.ABC):
 
     def load_target_lightcurves(
         self,
-        id_list: List[str] = None,
+        id_list: list[str] = None,
         only_flag_updated: bool = True,
         t_ref: Time = None,
     ):

--- a/aas2rto/query_managers/fink/__init__.py
+++ b/aas2rto/query_managers/fink/__init__.py
@@ -1,4 +1,4 @@
-from aas2rto.query_managers.fink.fink_base import BaseFinkQueryManager
+from aas2rto.query_managers.fink.fink_base import FinkBaseQueryManager
 from aas2rto.query_managers.fink.fink_ztf import FinkZTFQueryManager
 from aas2rto.query_managers.fink.fink_lsst import FinkLSSTQueryManager
 from aas2rto.query_managers.fink.fink_portal_client import (

--- a/aas2rto/query_managers/fink/__init__.py
+++ b/aas2rto/query_managers/fink/__init__.py
@@ -1,4 +1,7 @@
-from aas2rto.query_managers.fink.fink_base import FinkBaseQuery
+from aas2rto.query_managers.fink.fink_base import BaseFinkQueryManager
 from aas2rto.query_managers.fink.fink_ztf import FinkZTFQueryManager
 from aas2rto.query_managers.fink.fink_lsst import FinkLSSTQueryManager
-from aas2rto.query_managers.fink.fink_query import FinkZTFQuery, FinkLSSTQuery
+from aas2rto.query_managers.fink.fink_portal_client import (
+    FinkLSSTPortalClient,
+    FinkZTFPortalClient,
+)

--- a/aas2rto/query_managers/fink/fink_lsst.py
+++ b/aas2rto/query_managers/fink/fink_lsst.py
@@ -7,18 +7,18 @@ from astropy.coordinates import SkyCoord
 from astropy.time import Time
 
 from aas2rto.exc import MissingCoordinatesError
-from aas2rto.query_managers.fink.fink_base import FinkBaseQueryManager
-from aas2rto.query_managers.fink.fink_query import FinkLSSTQuery
+from aas2rto.query_managers.fink.fink_base import BaseFinkQueryManager
+from aas2rto.query_managers.fink.fink_portal_client import FinkLSSTPortalClient
 from aas2rto.target import Target
 
 
 logger = getLogger(__name__.split(".")[-1])
 
 
-class FinkLSSTQueryManager(FinkBaseQueryManager):
+class FinkLSSTQueryManager(BaseFinkQueryManager):
     name = "fink_lsst"
     id_resolving_order = ("lsst", "fink_lsst", "tns")
-    fink_query = FinkLSSTQuery
+    portal_client_class = FinkLSSTPortalClient
     target_id_key = "diaObjectId"
     alert_id_key = "diaSourceId"
 

--- a/aas2rto/query_managers/fink/fink_lsst.py
+++ b/aas2rto/query_managers/fink/fink_lsst.py
@@ -1,54 +1,136 @@
+import pickle
 import json
 from logging import getLogger
-from typing import Dict, List, Tuple
+from typing import NoReturn
+
+import numpy as np
+
+import pandas as pd
 
 from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.time import Time
 
+from aas2rto import utils
 from aas2rto.exc import MissingCoordinatesError
-from aas2rto.query_managers.fink.fink_base import BaseFinkQueryManager
+from aas2rto.query_managers.fink.fink_base import (
+    FinkBaseQueryManager,
+    FinkAlert,
+    readstamp,
+    EXTRA_FINK_ALERT_KEYS,
+)
 from aas2rto.query_managers.fink.fink_portal_client import FinkLSSTPortalClient
 from aas2rto.target import Target
 
 
 logger = getLogger(__name__.split(".")[-1])
 
+LSST_TARGET_ID_KEY = "diaObjectId"
+LSST_ALERT_ID_KEY = "diaSourceId"
 
-class FinkLSSTQueryManager(BaseFinkQueryManager):
+
+class FinkLSSTQueryManager(FinkBaseQueryManager):
     name = "fink_lsst"
     id_resolving_order = ("lsst", "fink_lsst", "tns")
+    target_id_key = LSST_TARGET_ID_KEY
+    alert_id_key = LSST_ALERT_ID_KEY
     portal_client_class = FinkLSSTPortalClient
-    target_id_key = "diaObjectId"
-    alert_id_key = "diaSourceId"
+    # DO NOT init portal_client here: happens in QM init, in case credentials needed...
 
-    def process_single_alert(
-        self, alert_data: Tuple[str, Dict, str], t_ref: Time = None
-    ):
+    def process_single_alert(self, alert_data: FinkAlert, t_ref: Time = None):
         topic, data, key = alert_data
-        fink_id = data["diaObject"]["diaObjectId"]
-        alert_id = data["diaSource"]["diaSourceId"]
-        return process_lsst_alert(
+        fink_id = data["diaObject"][self.target_id_key]
+        alert_id = data["diaSource"][self.alert_id_key]
+        return process_fink_lsst_alert(
             alert_data,
             alert_filepath=self.get_alert_filepath(fink_id, alert_id),
-            cutout_filepath=self.get_cutouts_filepath(fink_id, alert_id),
+            cutouts_filepath=self.get_cutouts_filepath(fink_id, alert_id),
             t_ref=t_ref,
         )
 
-    def add_target_from_alert(self, alert: Dict, t_ref: Time = None):
-        return target_from_lsst_alert(alert, t_ref=t_ref)
+    def new_target_from_alert(self, processed_alert: dict, t_ref: Time = None):
+        return target_from_fink_lsst_alert(processed_alert, t_ref=t_ref)
 
-    def add_target_from_record(self, query_record: dict):
+    def new_target_from_record(self, query_record: dict, t_ref: Time = None):
         # Wait to read FINK LSST Docs?
+        return target_from_fink_lsst_alert(query_record, t_ref=t_ref)
+
+    def apply_updates_from_alert(
+        self, processed_alert: dict, t_ref: Time = None
+    ) -> NoReturn:
+        fink_id = processed_alert[self.target_id_key]
+
+        target = self.target_lookup.get(fink_id, None)
+        if target is None:
+            logger.warning(f"No target '{fink_id}' - can't apply updates!")
+            return
+        apply_fink_lsst_updates_to_target(target, processed_alert, t_ref)
+
+    def process_fink_lightcurve(self, unprocessed_lc: pd.DataFrame):
+        return process_fink_lsst_lightcurve(unprocessed_lc)
+
+    def load_missing_alerts_for_target(self, fink_id: str):
+        pass
+        # There should be no missing alerts in the LC - fink ingests LSST immediately.
+
+    def load_cutouts_for_alert(self, fink_id: str, alert_id: int):
         pass
 
 
-def target_from_lsst_alert(alert: dict, t_ref: Time = None):
+def process_fink_lsst_alert(
+    alert_data: FinkAlert,
+    alert_filepath=None,
+    cutouts_filepath=None,
+    t_ref: Time = None,
+):
+    topic, data, key = alert_data
+
+    object_data: dict = data["diaObject"]
+    alert: dict = data["diaSource"]
+
+    fink_id: int = object_data[LSST_TARGET_ID_KEY]
+    alert_id: int = alert[LSST_ALERT_ID_KEY]
+
+    # Now modify the alert dict - diaSourceId (alert_id) is already included
+    alert[LSST_TARGET_ID_KEY] = fink_id
+    alert["topic"] = topic
+    alert["mjd"] = alert["midpointMjdTai"]
+    alert["tag"] = "valid"  # if it's arrived as an alert, it must be valid...
+    alert["nDiaSources"] = object_data["nDiaSources"]
+
+    extra_data = {k: data[k] for k in EXTRA_FINK_ALERT_KEYS if k in data}
+    utils.check_missing_config_keys(
+        data, EXTRA_FINK_ALERT_KEYS, name=f"fink_lsst.{topic}.{fink_id}.{alert_id}"
+    )
+    alert.update(extra_data)
+
+    # POP any cutouts first, so we don't try to serialise them into JSON - fails!
+    cutouts = {}
+    for imtype in FinkLSSTPortalClient.imtypes:
+        cutout_key = f"cutout{imtype}"
+        alert_data = alert.pop(cutout_key, None)
+        if alert_data is not None:
+            cutout = readstamp(alert_data)
+            cutouts[imtype.lower()] = cutout
+
+    if alert_filepath is not None:
+        with open(alert_filepath, "w+") as f:
+            json.dump(alert, f)
+
+    if cutouts_filepath is not None:
+        if len(cutouts) > 0:
+            with open(cutouts_filepath, "wb+") as f:
+                pickle.dump(cutouts, f)
+
+    return alert
+
+
+def target_from_fink_lsst_alert(processed_alert: dict, t_ref: Time = None):
     t_ref = t_ref or Time.now()
 
-    target_id = alert["diaObjectId"]
-    ra = alert.get("ra", None)
-    dec = alert.get("dec", None)
+    target_id = processed_alert[LSST_TARGET_ID_KEY]
+    ra = processed_alert.get("ra", None)
+    dec = processed_alert.get("dec", None)
     if (ra is None) or (dec is None):
         raise MissingCoordinatesError(f"ra: {ra} or dec: {dec} is None!")
     coord = SkyCoord(ra=ra, dec=dec, unit=u.deg)
@@ -56,23 +138,35 @@ def target_from_lsst_alert(alert: dict, t_ref: Time = None):
     return Target(target_id, coord, source="fink_lsst", alt_ids=alt_ids, t_ref=t_ref)
 
 
-def process_lsst_alert(
-    alert_data, alert_filepath=None, cutout_filepath=None, t_ref: Time = None
-):
-    topic, data, key = alert_data
-    alert = data["diaSource"]
-    alert["topic"] = topic
-    alert["mjd"] = alert["midpointMjdTai"]
+def apply_fink_lsst_updates_to_target(
+    target: Target, processed_alert: dict, t_ref: Time = None
+) -> NoReturn:
+    t_ref = t_ref or Time.now()
 
-    diaObject = data["diaObject"]
-    alert["diaObjectId"] = diaObject["diaObjectId"]
-    alert["nDiaSources"] = diaObject["nDiaSources"]
-    alert["tag"] = "valid"
+    fink_id = processed_alert[LSST_TARGET_ID_KEY]
+    topic = processed_alert["topic"]
+    alert_id = processed_alert[LSST_ALERT_ID_KEY]
+    flux = processed_alert["psfFlux"]  # flux is in nJy
+    mag = -2.5 * np.log10(flux) + 31.4
+    band = processed_alert["band"]
+    mjd = processed_alert["mjd"]
+    t_str = Time(mjd, format="mjd").strftime("%y-%m-%d %H:%M")
 
-    if alert_filepath is not None:
-        with open(alert_filepath, "w+") as f:
-            json.dump(alert, f)
+    msg = (
+        f"New FINK-LSST alert for {target.target_id} ({fink_id}) from {topic}!"
+        f"\n    mag={mag:.1f} in band '{band}' at {t_str} (alert_id={alert_id})"
+    )
+    target.updated = True
+    target.info_messages.append(msg)
+    return
 
-    if cutout_filepath is not None:
-        logger.warning("don't know how LSST cutouts are handled!")
-    return alert
+
+def process_fink_lsst_lightcurve(unprocessed_lc: pd.DataFrame):
+    lightcurve = unprocessed_lc.copy(deep=True)
+
+    if lightcurve.empty:
+        req_columns = "diaObjectId mjd diaSourceId tag".split()
+        return pd.DataFrame(columns=req_columns)
+
+    if LSST_ALERT_ID_KEY not in lightcurve.columns:
+        lightcurve.loc[:, LSST_ALERT_ID_KEY] = -1

--- a/aas2rto/query_managers/fink/fink_portal_client.py
+++ b/aas2rto/query_managers/fink/fink_portal_client.py
@@ -21,7 +21,7 @@ class FinkPortalClientError(Exception):
     pass
 
 
-class BaseFinkPortalClient(abc.ABC):
+class FinkBasePortalClient(abc.ABC):
 
     TIMEOUT_LIKELY = 58.0
 
@@ -41,7 +41,7 @@ class BaseFinkPortalClient(abc.ABC):
         pass
 
     def __init__(self):
-        pass
+        pass  # In case of credentials required, implement here
 
     @staticmethod
     def fix_dict_keys_inplace(data: dict):
@@ -241,13 +241,13 @@ class BaseFinkPortalClient(abc.ABC):
         )
 
 
-class FinkZTFPortalClient(BaseFinkPortalClient):
+class FinkZTFPortalClient(FinkBasePortalClient):
     api_url = "https://api.ztf.fink-portal.org/api/v1"
     id_key = "objectId"
-    imtypes = ("Difference", "Template", "Science")
+    imtypes = ("Difference", "Science", "Template")
 
 
-class FinkLSSTPortalClient(BaseFinkPortalClient):
+class FinkLSSTPortalClient(FinkBasePortalClient):
     api_url = "https://api.lsst.fink-portal.org/api/v1"
     id_key = "diaObjectId"
-    imtypes = ("Difference", "Template")
+    imtypes = ("Difference", "Science", "Template")

--- a/aas2rto/query_managers/fink/fink_portal_client.py
+++ b/aas2rto/query_managers/fink/fink_portal_client.py
@@ -17,11 +17,11 @@ from astropy.time import Time
 logger = getLogger(__name__.split(".")[-1])
 
 
-class FinkQueryError(Exception):
+class FinkPortalClientError(Exception):
     pass
 
 
-class FinkBaseQuery(abc.ABC):
+class BaseFinkPortalClient(abc.ABC):
 
     TIMEOUT_LIKELY = 58.0
 
@@ -51,11 +51,10 @@ class FinkBaseQuery(abc.ABC):
             data[new_key] = data.pop(old_key)
         # NO RETURN - dictionary is modified "in place"...
 
-    @classmethod
-    def process_data(cls, data, fix_keys=True, return_type="records", df_kwargs=None):
+    def process_data(self, data, fix_keys=True, return_type="records", df_kwargs=None):
         if fix_keys:
             for row in data:
-                cls.fix_dict_keys_inplace(row)
+                self.fix_dict_keys_inplace(row)
         if return_type == "records":
             return data
         elif return_type == "pandas":
@@ -78,49 +77,46 @@ class FinkBaseQuery(abc.ABC):
         """
         return {k.rstrip("_"): v for k, v in kwargs.items()}
 
-    @classmethod
     def process_response(
-        cls, response: requests.Response, fix_keys=True, return_type=None
+        self, response: requests.Response, fix_keys=True, return_type=None
     ):
         if response.status_code in [404, 500, 504]:
             logger.error("\033[31;1mFinkQuery: error rasied\033[0m")
-            if response.elapsed.total_seconds() > cls.TIMEOUT_LIKELY:
+            if response.elapsed.total_seconds() > self.TIMEOUT_LIKELY:
                 logger.error("likely a timeout error")
             if isinstance(response.content, bytes):
-                raise FinkQueryError(response.content.decode())
+                raise FinkPortalClientError(response.content.decode())
             else:
-                raise FinkQueryError(response.content)
+                raise FinkPortalClientError(response.content)
         data = json.loads(response.content)
-        return cls.process_data(data, fix_keys=fix_keys, return_type=return_type)
+        return self.process_data(data, fix_keys=fix_keys, return_type=return_type)
 
-    @classmethod
     def do_post(
-        cls, service: str, process=True, fix_keys=True, return_type=None, **kwargs
+        self, service: str, process=True, fix_keys=True, return_type=None, **kwargs
     ):
-        kwargs = cls.process_kwargs(**kwargs)
+        kwargs = self.process_kwargs(**kwargs)
         response: requests.Response = requests.post(
-            f"{cls.api_url}/{service}", json=kwargs
+            f"{self.api_url}/{service}", json=kwargs
         )
         if response.status_code != 200:
             time.sleep(0.1)
             msg = f"query for '{service}' returned status {response.status_code}"
             logger.warning(msg)
         if process:
-            return cls.process_response(
+            return self.process_response(
                 response, fix_keys=fix_keys, return_type=return_type
             )
         return response
 
-    @classmethod
-    def do_get(cls, service: str, process=True, **kwargs):
+    def do_get(self, service: str, process=True, **kwargs):
         response: requests.Response = requests.get(
-            f"{cls.api_url}/{service}", json=kwargs
+            f"{self.api_url}/{service}", json=kwargs
         )
         if response.status_code != 200:
             if isinstance(response.content, bytes):
-                raise FinkQueryError(response.content.decode())
+                raise FinkPortalClientError(response.content.decode())
             else:
-                raise FinkQueryError(response.content)
+                raise FinkPortalClientError(response.content)
         if process:
             try:
                 return json.loads(response.content)
@@ -128,27 +124,23 @@ class FinkBaseQuery(abc.ABC):
                 return response.content.decode()
         return response
 
-    @classmethod
-    def objects(cls, fix_keys=True, return_type=None, **kwargs):
-        return cls.do_post(
+    def objects(self, fix_keys=True, return_type=None, **kwargs):
+        return self.do_post(
             "objects", fix_keys=fix_keys, return_type=return_type, **kwargs
         )
 
-    @classmethod
-    def cutouts(cls, **kwargs):
-        if kwargs.get("kind", None) not in cls.imtypes:
-            raise ValueError(f"provide `kind` as one of {cls.imtypes}")
-        return cls.do_post("cutouts", fix_keys=False, **kwargs)
+    def cutouts(self, **kwargs):
+        if kwargs.get("kind", None) not in self.imtypes:
+            raise ValueError(f"provide `kind` as one of {self.imtypes}")
+        return self.do_post("cutouts", fix_keys=False, **kwargs)
 
-    @classmethod
-    def latests(cls, fix_keys=True, return_type=None, **kwargs):
-        return cls.do_post(
+    def latests(self, fix_keys=True, return_type=None, **kwargs):
+        return self.do_post(
             "latests", fix_keys=fix_keys, return_type=return_type, **kwargs
         )
 
-    @classmethod
     def latests_query_and_collate(
-        cls,
+        self,
         t_start: Time,
         t_stop: Time = None,
         step=3 * u.h,
@@ -172,7 +164,7 @@ class FinkBaseQuery(abc.ABC):
             payload["startdate"] = t1.iso
             payload["stopdate"] = t2.iso
             logger.info(f"start query {t1_str} - {t2_str}")
-            result = cls.latests(fix_keys=fix_keys, return_type=return_type, **payload)
+            result = self.latests(fix_keys=fix_keys, return_type=return_type, **payload)
             if len(result) == n:
                 msg = f"{t1_str} - {t2_str} returned {n} rows. choose shorter timestep!"
                 logger.warning(msg)
@@ -183,91 +175,79 @@ class FinkBaseQuery(abc.ABC):
         elif return_type == "pandas":
             if len(results) > 0:
                 return pd.concat(results)
-            return pd.DataFrame(columns=[cls.id_key])
+            return pd.DataFrame(columns=[self.id_key])
         elif return_type == "astropy":
             if len(results) > 0:
                 return vstack(results)
-            return Table(names=[cls.id_key])
+            return Table(names=[self.id_key])
         else:
             msg = f"Unknown return_type='{return_type}': Use None, 'pandas', 'astropy'"
             raise ValueError(msg)
 
-    @classmethod
-    def classes(cls, fix_keys=True, process=True, return_type=None, **kwargs):
-        return cls.do_get("classes", process=process, **kwargs)
+    def classes(self, fix_keys=True, process=True, return_type=None, **kwargs):
+        return self.do_get("classes", process=process, **kwargs)
 
-    @classmethod
-    def explorer(cls, fix_keys=True, return_type=None, **kwargs):
-        return cls.do_post(
+    def explorer(self, fix_keys=True, return_type=None, **kwargs):
+        return self.do_post(
             "explorer", fix_keys=fix_keys, return_type=return_type, **kwargs
         )
 
-    @classmethod
-    def conesearch(cls, fix_keys=True, return_type=None, **kwargs):
-        return cls.do_post(
+    def conesearch(self, fix_keys=True, return_type=None, **kwargs):
+        return self.do_post(
             "conesearch", fix_keys=fix_keys, return_type=return_type, **kwargs
         )
 
-    @classmethod
-    def sso(cls, fix_keys=True, return_type=None, **kwargs):
-        return cls.do_post("sso", fix_keys=fix_keys, return_type=return_type, **kwargs)
+    def sso(self, fix_keys=True, return_type=None, **kwargs):
+        return self.do_post("sso", fix_keys=fix_keys, return_type=return_type, **kwargs)
 
-    @classmethod
-    def ssocand(cls, fix_keys=True, return_type=None, **kwargs):
-        return cls.do_post(
+    def ssocand(self, fix_keys=True, return_type=None, **kwargs):
+        return self.do_post(
             "ssocand", fix_keys=fix_keys, return_type=return_type, **kwargs
         )
 
-    @classmethod
-    def resolver(cls, fix_keys=True, return_type=None, **kwargs):
-        return cls.do_post(
+    def resolver(self, fix_keys=True, return_type=None, **kwargs):
+        return self.do_post(
             "resolver", fix_keys=fix_keys, return_type=return_type, **kwargs
         )
 
-    @classmethod
-    def tracklet(cls, fix_keys=True, return_type=None, **kwargs):
-        return cls.do_post(
+    def tracklet(self, fix_keys=True, return_type=None, **kwargs):
+        return self.do_post(
             "tracklet", fix_keys=fix_keys, return_type=return_type, **kwargs
         )
 
-    @classmethod
-    def schema(cls, fix_keys=True, return_type=None, **kwargs):
-        return cls.do_get(
+    def schema(self, fix_keys=True, return_type=None, **kwargs):
+        return self.do_get(
             "schema", fix_keys=fix_keys, return_type=return_type, **kwargs
         )
 
-    @classmethod
-    def skymap(cls, fix_keys=True, return_type=None, **kwargs):
-        return cls.do_post(
+    def skymap(self, fix_keys=True, return_type=None, **kwargs):
+        return self.do_post(
             "skymap", fix_keys=fix_keys, return_type=return_type, **kwargs
         )
 
-    @classmethod
-    def statistics(cls, fix_keys=True, return_type=None, **kwargs):
-        return cls.do_post(
+    def statistics(self, fix_keys=True, return_type=None, **kwargs):
+        return self.do_post(
             "statistics", fix_keys=fix_keys, return_type=return_type, **kwargs
         )
 
-    @classmethod
-    def anomaly(cls, fix_keys=True, return_type=None, **kwargs):
-        return cls.do_post(
+    def anomaly(self, fix_keys=True, return_type=None, **kwargs):
+        return self.do_post(
             "anomaly", fix_keys=fix_keys, return_type=return_type, **kwargs
         )
 
-    @classmethod
-    def ssoft(cls, fix_keys=True, return_type=None, **kwargs):
-        return cls.do_post(
+    def ssoft(self, fix_keys=True, return_type=None, **kwargs):
+        return self.do_post(
             "ssoft", fix_keys=fix_keys, return_type=return_type, **kwargs
         )
 
 
-class FinkZTFQuery(FinkBaseQuery):
+class FinkZTFPortalClient(BaseFinkPortalClient):
     api_url = "https://api.ztf.fink-portal.org/api/v1"
     id_key = "objectId"
     imtypes = ("Difference", "Template", "Science")
 
 
-class FinkLSSTQuery(FinkBaseQuery):
+class FinkLSSTPortalClient(BaseFinkPortalClient):
     api_url = "https://api.lsst.fink-portal.org/api/v1"
     id_key = "diaObjectId"
     imtypes = ("Difference", "Template")

--- a/aas2rto/query_managers/fink/fink_ztf.py
+++ b/aas2rto/query_managers/fink/fink_ztf.py
@@ -17,62 +17,73 @@ from astropy.coordinates import SkyCoord
 from astropy.io import fits
 from astropy.time import Time
 
+from aas2rto import utils
 from aas2rto.exc import MissingCoordinatesError
-from aas2rto.query_managers.fink.fink_base import BaseFinkQueryManager, FinkAlert
+from aas2rto.query_managers.fink.fink_base import (
+    FinkBaseQueryManager,
+    FinkAlert,
+    readstamp,
+    EXTRA_FINK_ALERT_KEYS,
+)
 from aas2rto.query_managers.fink.fink_portal_client import FinkZTFPortalClient
 from aas2rto.target import Target
-from aas2rto.utils import check_missing_config_keys
 
 logger = getLogger(__name__.split(".")[-1])
 
+ZTF_TARGET_ID_KEY = "objectId"
+ZTF_ALERT_ID_KEY = "candid"
 
-class FinkZTFQueryManager(BaseFinkQueryManager):
+
+class FinkZTFQueryManager(FinkBaseQueryManager):
     name = "fink_ztf"
     id_resolving_order = ("ztf", "ztf_fink", "tns")
-    target_id_key = "objectId"
-    alert_id_key = "candid"
+    target_id_key = ZTF_TARGET_ID_KEY
+    alert_id_key = ZTF_ALERT_ID_KEY
     portal_client_class = FinkZTFPortalClient
     # DO NOT init portal_client here: happens in QM init, in case credentials needed...
 
     def process_single_alert(self, alert_data: FinkAlert, t_ref: Time = None) -> dict:
+        """
+        alerts are processed in such a way that they can be included in the lightcurve
+        at a later date
+        """
+
         topic, data, key = alert_data
-        fink_id = data["objectId"]
-        candid = data["candid"]
-        return process_ztf_alert(
+        fink_id = data[self.target_id_key]
+        candid = data[self.alert_id_key]
+        return process_fink_ztf_alert(
             alert_data,
             alert_filepath=self.get_alert_filepath(fink_id, candid),
             cutouts_filepath=self.get_cutouts_filepath(fink_id, candid),
             t_ref=t_ref,
         )
 
-    def add_target_from_alert(self, processed_alert: dict, t_ref=None) -> Target:
+    def new_target_from_alert(self, processed_alert: dict, t_ref=None) -> Target:
+        t_ref = t_ref or Time.now()
+        return target_from_fink_ztf_alert(processed_alert, t_ref=t_ref)
+
+    def new_target_from_record(self, query_record: dict, t_ref: Time = None) -> Target:
+        # Actually, the result of a ZTF classifier query!
+        # looks just like a processed alert... so we can just re-use that function!
+        return self.new_target_from_alert(processed_alert=query_record, t_ref=t_ref)
+
+    def apply_updates_from_alert(
+        self, processed_alert: dict, t_ref: Time = None
+    ) -> NoReturn:
         t_ref = t_ref or Time.now()
 
-        target = target_from_ztf_alert(processed_alert, t_ref=t_ref)
-        self.target_lookup.add_target(target)
-        return target
-
-    def add_target_from_record(self, query_record: dict, t_ref: Time = None) -> Target:
-        # Actually, the result of a ZTF classifier query
-        # looks just like a processed alert...
-        # so we can just re-use that function!
-        return self.add_target_from_alert(processed_alert=query_record, t_ref=t_ref)
-
-    def apply_updates_from_alert(self, processed_alert: dict, t_ref=None) -> NoReturn:
-        t_ref = t_ref or Time.now()
-
-        fink_id = processed_alert["objectId"]
+        fink_id = processed_alert[self.target_id_key]
 
         target = self.target_lookup.get(fink_id, None)
         if target is None:
             logger.warning(f"No target {fink_id} - can't apply updates!")
             return
-        apply_ztf_updates_to_target(target, processed_alert, t_ref=t_ref)
+        apply_fink_ztf_updates_to_target(target, processed_alert, t_ref=t_ref)
 
     def process_fink_lightcurve(self, unprocessed_lc: pd.DataFrame) -> pd.DataFrame:
-        return process_ztf_lightcurve(unprocessed_lc)
+        return process_fink_ztf_lightcurve(unprocessed_lc)
 
-    def load_missing_alerts_for_target(self, fink_id: str) -> Target | None:
+    def load_missing_alerts_for_target(self, fink_id: str) -> bool:
         target = self.target_lookup.get(fink_id, None)
         if target is None:
             return False
@@ -80,7 +91,7 @@ class FinkZTFQueryManager(BaseFinkQueryManager):
         fink_data = target.get_target_data(self.name)
         alert_directory = self.get_alert_directory(fink_id, mkdir=False)
         if not alert_directory.exists():
-            return False  # There obviously aren't any alerts here.
+            return False  # There obviously aren't any alerts here - glob will fail.
 
         available_alert_files = alert_directory.glob("*.json")
         available_alert_ids = [int(a.stem) for a in available_alert_files]
@@ -118,90 +129,37 @@ class FinkZTFQueryManager(BaseFinkQueryManager):
         return cutouts
 
 
-def target_from_ztf_alert(processed_alert: dict, t_ref: Time = None):
-
-    target_id = processed_alert["objectId"]
-    ra = processed_alert.get("ra", None)
-    dec = processed_alert.get("dec", None)
-    if (ra is None) or (dec is None):
-        raise MissingCoordinatesError(f"ra: {ra} or dec: {dec} is None!")
-
-    alt_ids = {"ztf": target_id, "fink_ztf": target_id}
-    coord = SkyCoord(ra=ra, dec=dec, unit=u.deg)
-    return Target(target_id, coord, source="fink_ztf", alt_ids=alt_ids, t_ref=t_ref)
-
-
-def process_ztf_lightcurve(unprocessed_lc: pd.DataFrame) -> pd.DataFrame:
-    lightcurve = unprocessed_lc.copy(deep=True)
-
-    if lightcurve.empty:
-        return pd.DataFrame(columns="objectId mjd jd candid tag".split())
-
-    lightcurve.sort_values("jd", inplace=True, ignore_index=True)
-    mjd = Time(lightcurve["jd"], format="jd").mjd
-    lightcurve.insert(1, "mjd", mjd)
-    if "candid" not in lightcurve.columns:
-        lightcurve.loc[:, "candid"] = -1  # INTEGER!
-    return lightcurve
-
-
-def apply_ztf_updates_to_target(
-    target: Target, processed_alert: dict, t_ref: Time = None
-):
-    t_ref = t_ref or Time.now()
-
-    fink_id = processed_alert["objectId"]
-    topic = processed_alert["topic"]
-    candid = processed_alert["candid"]
-    mag = processed_alert["magpsf"]
-    band = processed_alert["fid"]
-    mjd = processed_alert["mjd"]
-    t_str = Time(mjd, format="mjd").strftime("%y-%m-%d %H:%M")
-
-    msg = (
-        f"New FINK-ZTF alert for {target.target_id} ({fink_id}) from {topic}!"
-        f"\n    mag={mag:.1f} in band '{band}' at {t_str} (alert_id={candid})"
-    )
-    target.updated = True
-    target.info_messages.append(msg)
-    return
-
-
-extra_ztf_alert_keys = (
-    # "timestamp", # doesn't exist anymore?!
-    "cdsxmatch",
-    "rf_snia_vs_nonia",
-    "snn_snia_vs_nonia",
-    "snn_sn_vs_all",
-    "mulens",
-    "roid",
-    "nalerthist",
-    "rf_kn_vs_nonkn",
-)
-
-
-def process_ztf_alert(
+def process_fink_ztf_alert(
     alert_data: tuple[str, dict, str],
     alert_filepath: Path = None,
     cutouts_filepath: Path = None,
     t_ref: Time = None,
 ):
+    """
+    The purpose of "flattening" alerts from nested dicts is so they can easily be
+    appended to LCs.
+    """
+
     topic, data, key = alert_data  # Unpack tuple...
 
-    fink_id: str = data["objectId"]
-    alert: dict = data["candidate"]
-    candid: int = data["candid"]
+    # Extract some key info.
+    fink_id: str = data[ZTF_TARGET_ID_KEY]  # T_ID_KEY = "objectId"
+    alert_id: int = data[ZTF_ALERT_ID_KEY]  # A_ID_KEY = "candid"
 
-    alert["objectId"] = fink_id
+    # The data to be used as "the alert"
+    alert: dict = data["candidate"]
+
+    # Now modify the alert dict
+    alert[ZTF_TARGET_ID_KEY] = fink_id
     alert["topic"] = topic
-    alert["tag"] = "valid"  # must be valid if it's arrived as an alert
     if "mjd" not in alert:
         alert["mjd"] = Time(alert["jd"], format="jd").mjd
-    alert["candid"] = candid  # the long ~20 digit ID number.
+    alert["tag"] = "valid"  # must be valid if it's arrived as an alert
+    alert[ZTF_ALERT_ID_KEY] = alert_id  # the long ~20 digit ID number.
 
-    extra_data = {k: data[k] for k in extra_ztf_alert_keys if k in data}
-    check_missing_config_keys(
-        data, extra_ztf_alert_keys, name=f"fink.{topic}.{fink_id}.{candid}"
+    extra_data = {k: data[k] for k in EXTRA_FINK_ALERT_KEYS if k in data}
+    utils.check_missing_config_keys(
+        data, EXTRA_FINK_ALERT_KEYS, name=f"fink_ztf.{topic}.{fink_id}.{alert_id}"
     )
     alert.update(extra_data)
 
@@ -223,40 +181,54 @@ def process_ztf_alert(
     return alert
 
 
-def readstamp(stamp: str, return_type="array", gzipped=True) -> np.array:
-    """Read the stamp data inside an alert.
-    Copied directly from Fink's utils:
-    https://github.com/astrolabsoftware/fink-science-portal/blob/master/apps/utils.py#L216 ...
+def target_from_fink_ztf_alert(processed_alert: dict, t_ref: Time = None):
 
-    Parameters
-    ----------
-    stamp: str
-        String containing binary data for the stamp
-    return_type: str
-        Data block of HDU 0 (`array`) or original FITS uncompressed (`FITS`) as file-object.
-        Default is `array`.
+    target_id = processed_alert[ZTF_TARGET_ID_KEY]
+    alert_id = processed_alert[ZTF_ALERT_ID_KEY]
+    ra = processed_alert.get("ra", None)
+    dec = processed_alert.get("dec", None)
+    if (ra is None) or (dec is None):
+        msg = (
+            f"'ra': {ra} or 'dec': {dec} is None! (in {target_id} alert_id {alert_id})"
+        )
+        raise MissingCoordinatesError(msg)
 
-    Returns
-    -------
-    data: np.array
-        2D array containing image data (`array`) or FITS file uncompressed as file-object (`FITS`)
-    """
+    alt_ids = {"ztf": target_id, "fink_ztf": target_id}
+    coord = SkyCoord(ra=ra, dec=dec, unit=u.deg)
+    return Target(target_id, coord, source="fink_ztf", alt_ids=alt_ids, t_ref=t_ref)
 
-    def extract_stamp(fitsdata):
-        with fits.open(fitsdata, ignore_missing_simple=True) as hdul:
-            if return_type == "array":
-                data = hdul[0].data
-            elif return_type == "FITS":
-                data = io.BytesIO()
-                hdul.writeto(data)
-                data.seek(0)
-        return data
 
-    if not isinstance(stamp, io.BytesIO):
-        stamp = io.BytesIO(stamp)
+def apply_fink_ztf_updates_to_target(
+    target: Target, processed_alert: dict, t_ref: Time = None
+):
+    t_ref = t_ref or Time.now()
 
-    if gzipped:
-        with gzip.open(stamp, "rb") as f:
-            return extract_stamp(io.BytesIO(f.read()))
-    else:
-        return extract_stamp(stamp)
+    fink_id = processed_alert[ZTF_TARGET_ID_KEY]
+    topic = processed_alert["topic"]
+    alert_id = processed_alert[ZTF_ALERT_ID_KEY]
+    mag = processed_alert["magpsf"]
+    band = processed_alert["fid"]  # "filter-id"
+    mjd = processed_alert["mjd"]
+    t_str = Time(mjd, format="mjd").strftime("%y-%m-%d %H:%M")
+
+    msg = (
+        f"New FINK-ZTF alert for {target.target_id} ({fink_id}) from {topic}!"
+        f"\n    mag={mag:.1f} in band '{band}' at {t_str} (alert_id={alert_id})"
+    )
+    target.updated = True
+    target.info_messages.append(msg)
+    return
+
+
+def process_fink_ztf_lightcurve(unprocessed_lc: pd.DataFrame) -> pd.DataFrame:
+    lightcurve = unprocessed_lc.copy(deep=True)
+
+    if lightcurve.empty:
+        return pd.DataFrame(columns="objectId mjd jd candid tag".split())
+
+    lightcurve.sort_values("jd", inplace=True, ignore_index=True)
+    mjd = Time(lightcurve["jd"], format="jd").mjd
+    lightcurve.insert(1, "mjd", mjd)
+    if "candid" not in lightcurve.columns:
+        lightcurve.loc[:, "candid"] = -1  # INTEGER!
+    return lightcurve

--- a/aas2rto/query_managers/fink/fink_ztf.py
+++ b/aas2rto/query_managers/fink/fink_ztf.py
@@ -18,20 +18,21 @@ from astropy.io import fits
 from astropy.time import Time
 
 from aas2rto.exc import MissingCoordinatesError
-from aas2rto.query_managers.fink.fink_base import FinkBaseQueryManager, FinkAlert
-from aas2rto.query_managers.fink.fink_query import FinkZTFQuery
+from aas2rto.query_managers.fink.fink_base import BaseFinkQueryManager, FinkAlert
+from aas2rto.query_managers.fink.fink_portal_client import FinkZTFPortalClient
 from aas2rto.target import Target
 from aas2rto.utils import check_missing_config_keys
 
 logger = getLogger(__name__.split(".")[-1])
 
 
-class FinkZTFQueryManager(FinkBaseQueryManager):
+class FinkZTFQueryManager(BaseFinkQueryManager):
     name = "fink_ztf"
     id_resolving_order = ("ztf", "ztf_fink", "tns")
-    fink_query = FinkZTFQuery
     target_id_key = "objectId"
     alert_id_key = "candid"
+    portal_client_class = FinkZTFPortalClient
+    # DO NOT init portal_client here: happens in QM init, in case credentials needed...
 
     def process_single_alert(self, alert_data: FinkAlert, t_ref: Time = None) -> dict:
         topic, data, key = alert_data
@@ -210,7 +211,7 @@ def process_ztf_alert(
 
     if cutouts_filepath is not None:
         cutouts = {}
-        for imtype in FinkZTFQuery.imtypes:
+        for imtype in FinkZTFPortalClient.imtypes:
             cutout_data = data.get("cutout" + imtype, {}).get("stampData", None)
             if cutout_data is None:
                 continue

--- a/aas2rto/query_managers/primary.py
+++ b/aas2rto/query_managers/primary.py
@@ -14,7 +14,8 @@ from aas2rto.target_lookup import TargetLookup
 # from aas2rto.query_managers.alerce import AlerceQueryManager
 from aas2rto.query_managers.atlas import AtlasQueryManager
 from aas2rto.query_managers.fink import FinkLSSTQueryManager, FinkZTFQueryManager
-from aas2rto.query_managers.lasair import LasairLSSTQueryManager, LasairZTFQueryManager
+
+# from aas2rto.query_managers.lasair import LasairLSSTQueryManager, LasairZTFQueryManager
 from aas2rto.query_managers.tns import TNSQueryManager
 from aas2rto.query_managers.yse import YSEQueryManager
 
@@ -28,8 +29,8 @@ EXPECTED_QUERY_MANAGERS = {
     "atlas": AtlasQueryManager,
     "fink_lsst": FinkLSSTQueryManager,
     "fink_ztf": FinkZTFQueryManager,
-    "lasair_lsst": LasairLSSTQueryManager,
-    "lasair_ztf": LasairZTFQueryManager,
+    # "lasair_lsst": LasairLSSTQueryManager,
+    # "lasair_ztf": LasairZTFQueryManager,
     "tns": TNSQueryManager,
     "yse": YSEQueryManager,
 }

--- a/aas2rto/query_managers/primary.py
+++ b/aas2rto/query_managers/primary.py
@@ -2,7 +2,6 @@ import time
 import warnings
 from logging import getLogger
 from pathlib import Path
-from typing import Dict
 
 from astropy.time import Time
 
@@ -40,7 +39,7 @@ class PrimaryQueryManager:
 
     def __init__(
         self,
-        config: Dict,
+        config: dict,
         target_lookup: TargetLookup,
         path_manager: PathManager,
     ):
@@ -68,7 +67,7 @@ class PrimaryQueryManager:
         self.query_managers = self._initialise_query_manager_lookup()
         self.initialize_query_managers()
 
-    def _initialise_query_manager_lookup(self) -> Dict[str, BaseQueryManager]:
+    def _initialise_query_manager_lookup(self) -> dict[str, BaseQueryManager]:
         """Only for type hinting..."""
         return {}
 

--- a/aas2rto/query_managers/primary.py
+++ b/aas2rto/query_managers/primary.py
@@ -14,11 +14,9 @@ from aas2rto.target_lookup import TargetLookup
 # from aas2rto.query_managers.alerce import AlerceQueryManager
 from aas2rto.query_managers.atlas import AtlasQueryManager
 from aas2rto.query_managers.fink import FinkLSSTQueryManager, FinkZTFQueryManager
-
-# from aas2rto.query_managers.lasair import LasairQueryManager
+from aas2rto.query_managers.lasair import LasairLSSTQueryManager, LasairZTFQueryManager
 from aas2rto.query_managers.tns import TNSQueryManager
-
-# from aas2rto.query_managers.yse import YseQueryManager
+from aas2rto.query_managers.yse import YSEQueryManager
 
 # from aas2rto.query_managers.sdss import SdssQueryManager
 
@@ -30,9 +28,10 @@ EXPECTED_QUERY_MANAGERS = {
     "atlas": AtlasQueryManager,
     "fink_lsst": FinkLSSTQueryManager,
     "fink_ztf": FinkZTFQueryManager,
-    # "lasair": LasairQueryManager,
+    "lasair_lsst": LasairLSSTQueryManager,
+    "lasair_ztf": LasairZTFQueryManager,
     "tns": TNSQueryManager,
-    # "yse": YseQueryManager,
+    "yse": YSEQueryManager,
 }
 
 

--- a/aas2rto/scoring/scoring_manager.py
+++ b/aas2rto/scoring/scoring_manager.py
@@ -1,6 +1,6 @@
 from logging import getLogger
 from pathlib import Path
-from typing import Callable, List
+from typing import Callable
 
 import numpy as np
 
@@ -23,7 +23,7 @@ def parse_scoring_result(result, func_name=""):
     err_msg = (
         f"scoring function {func_name} should return\n"
         f"    score : float, or\n"
-        f"    (score, comment_list) : Tuple[float, List[str]]"
+        f"    (score, comment_list) : tuple[float, list[str]]"
     )
     missing_comments = [f"function {func_name}: no score_comments provided"]
 
@@ -238,7 +238,7 @@ class ScoringManager:
 
     def new_target_initial_check(
         self, scoring_function: Callable, t_ref: Time = None
-    ) -> List[str]:
+    ) -> list[str]:
         """
         Evaluate the score for targets which have not been scored before (ie, new targets)
         with fixed observatory = `None`.

--- a/aas2rto/scoring/supernova_peak.py
+++ b/aas2rto/scoring/supernova_peak.py
@@ -3,7 +3,6 @@ import traceback
 import time
 import warnings
 from logging import getLogger
-from typing import Dict, List, Tuple
 
 import numpy as np
 
@@ -205,7 +204,7 @@ class SupernovaPeakScore:
         self.scoring_sources = scoring_sources
         # self.scoring_bands = scoring_bands
 
-    def __call__(self, target: Target, t_ref: Time) -> Tuple[float, List]:
+    def __call__(self, target: Target, t_ref: Time) -> tuple[float, list]:
         # t_ref = t_ref or Time.now()
 
         # to keep track

--- a/aas2rto/target.py
+++ b/aas2rto/target.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 import copy
 import time
 import traceback
 import warnings
 from logging import getLogger
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Union
+from typing import Any, Callable
 
 import numpy as np
 
@@ -44,14 +46,14 @@ class Target:
         the main name your target should be called by.
     coord: astropy.coordinates.SkyCoord
         the (latest) coordinate of the target.
-    target_data: Dict[str, aas2rto.target_data.TargetData]
+    target_data: dict[str, aas2rto.target_data.TargetData]
         A lookup of data from various sources.
         An entry for `fink` data, one for `atlas` data, one for `tns` data, etc...
     source:
         which data created this target? will be added into alt_ids. eg.
         >>> t = Target("T101", 30.0, 30.0, source="src01")
         >>> "src01" in t.alt_ids # True
-    alt_ids: Dict [str, str]
+    alt_ids: dict [str, str]
         Lookup to keep track of other names for this target.
         eg. ZTF24abcdef might also be called SN 24abc.
         So alt_ids might be: `{'tns': 'SN 24abc'}`
@@ -72,9 +74,9 @@ class Target:
         self,
         target_id: str,
         coord: SkyCoord,
-        target_data: Dict[str, TargetData] = None,
+        target_data: dict[str, TargetData] = None,
         source: str = None,
-        alt_ids: Dict[str, str] = None,
+        alt_ids: dict[str, str] = None,
         base_score: float = None,
         target_of_opportunity: bool = False,
         t_ref: Time = None,
@@ -304,7 +306,7 @@ class Target:
         return result[0]  # Otherwise just return the score.
 
     def get_latest_obs_score(
-        self, observatory: Union[Observer, str], return_time: bool = False
+        self, observatory: Observer | str, return_time: bool = False
     ):
         """
         Provide a string (observatory name) and return.
@@ -343,7 +345,7 @@ class Target:
         return result[0]  # Otherwise just return the score.
 
     def get_latest_obs_rank(
-        self, observatory: Union[Observer, str], return_time: bool = False
+        self, observatory: Observer | str, return_time: bool = False
     ):
         """
         Provide a string (observatory name) and return.

--- a/aas2rto/target.py
+++ b/aas2rto/target.py
@@ -82,14 +82,14 @@ class Target:
         t_ref = t_ref or Time.now()
 
         # Basics
-        self.target_id = target_id
+        self.target_id = str(target_id)
 
         self.update_coordinates(coord)
         self.base_score = base_score or self.default_base_score
         self.compiled_lightcurve = None
 
         # Target data
-        self.target_data = target_data or {}
+        self.target_data: dict[str, TargetData] = target_data or {}
 
         # Observatory data
         self.ephem_info = {}  # {"no_observatory": None}

--- a/aas2rto/target_data.py
+++ b/aas2rto/target_data.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import copy
 import warnings
 from logging import getLogger
-from typing import Union, Dict
 
 import numpy as np
 
@@ -117,7 +116,7 @@ class TargetData:
 
     def add_lightcurve(
         self,
-        lightcurve: Union[pd.DataFrame, Table],
+        lightcurve: pd.DataFrame | Table,
         tag_col: str = None,
         date_col: str = None,
         include_badqual: bool = False,

--- a/aas2rto/target_lookup.py
+++ b/aas2rto/target_lookup.py
@@ -3,7 +3,6 @@ import yaml
 from collections import defaultdict
 from logging import getLogger
 from pathlib import Path
-from typing import Dict, List
 
 import numpy as np
 
@@ -34,8 +33,8 @@ class TargetLookup:
 
     def __init__(self):
 
-        self.lookup: Dict[str, Target] = {}
-        self.id_mapping: Dict[str, str] = {}
+        self.lookup: dict[str, Target] = {}
+        self.id_mapping: dict[str, str] = {}
 
     def __len__(self):
         return len(self.lookup)
@@ -141,7 +140,7 @@ class TargetLookup:
                 raise ValueError(msg)
         self[target.target_id] = target
 
-    def add_target_list(self, target_list: List[Target]):
+    def add_target_list(self, target_list: list[Target]):
         for target in target_list:
             self.add_target(target)
 
@@ -254,7 +253,7 @@ class TargetLookup:
         self,
         target_id_list=None,
         t_ref=None,
-    ) -> List[Target]:
+    ) -> list[Target]:
         t_ref = t_ref or Time.now()
 
         if target_id_list is None:
@@ -345,7 +344,7 @@ def group_nearby_coordinates(coords: SkyCoord, seplimit=5 * u.arcsec) -> list:
 
     Returns
     -------
-    components : `List[List[int]]`
+    components : `list[list[int]]`
         list of lists: each sublist contains the indexes into `coords` which make
         up one connected group.
         Every index is included exactly once (ie. there are some sublists which
@@ -392,7 +391,7 @@ def dfs_util(connected: list, vert: int, edges: dict, visited: dict, depth=0):
     return connected
 
 
-def merge_targets(targets: List[Target], sort=False, warn_overwrite=True):
+def merge_targets(targets: list[Target], sort=False, warn_overwrite=True):
     """
     Merge all target data into a single target.
     Choose the first target (ie, with coords, target_id, etc), and

--- a/aas2rto/target_selector.py
+++ b/aas2rto/target_selector.py
@@ -285,12 +285,12 @@ class TargetSelector:
             logger.warning(f"failed:{len(failed)} (no compiled lc!)")
         return compiled, failed
 
-    def clear_output_plots(self, fig_fmt="png"):
-        for obs_name, observatory in self.observatory_manager.sites.items():
-            plot_dir = self.path_manager.get_output_plots_path(obs_name, mkdir=False)
-            if plot_dir.exists():
-                for plot in plot_dir.glob(f"*.{fig_fmt}"):
-                    os.remove(plot)
+    # def clear_output_plots(self, fig_fmt="png"):
+    #     for obs_name, observatory in self.observatory_manager.sites.items():
+    #         plot_dir = self.path_manager.get_output_plots_path(obs_name, mkdir=False)
+    #         if plot_dir.exists():
+    #             for plot in plot_dir.glob(f"*.{fig_fmt}"):
+    #                 os.remove(plot)
 
     def perform_web_tasks(self, t_ref: Time = None):
         self.web_manager.perform_all_web_tasks()
@@ -480,7 +480,7 @@ class TargetSelector:
         # ======================== Ranking and lists ======================== #
         t1 = time.perf_counter()
         if "ranking" not in skip_tasks:
-            self.clear_output_plots()  # In prep for the new outputs
+            # self.clear_output_plots()  # In prep for the new outputs
             self.outputs_manager.build_ranked_target_lists(
                 t_ref=t_ref, plots=True, write_list=True
             )

--- a/aas2rto/target_selector.py
+++ b/aas2rto/target_selector.py
@@ -10,7 +10,7 @@ import yaml
 from functools import partial
 from multiprocessing import Pool
 from pathlib import Path
-from typing import Callable, Dict, List, Set
+from typing import Callable
 
 import numpy as np
 
@@ -305,7 +305,7 @@ class TargetSelector:
         modeling_function: Callable = None,
         lightcurve_compiler: Callable = None,
         lc_plotting_function: Callable = None,
-        extra_plotting_functions: List[Callable] = None,
+        extra_plotting_functions: list[Callable] = None,
         skip_tasks: list = None,
         iteration: int = -1,
         t_ref: Time = None,
@@ -527,10 +527,10 @@ class TargetSelector:
         self,
         scoring_function: Callable = None,
         observatory_scoring_function: Callable = None,
-        modeling_function: List[Callable] = None,
+        modeling_function: list[Callable] = None,
         lightcurve_compiler: Callable = None,
         lc_plotting_function: Callable = None,
-        extra_plotting_functions: List[Callable] = None,
+        extra_plotting_functions: list[Callable] = None,
         recovery_file=False,
         skip_tasks=None,
         iterations=None,
@@ -554,7 +554,7 @@ class TargetSelector:
             It should have the 'standard' signature defined above.
             It should return:\n
                 `score : float`
-                `comments : List of str, optional`
+                `comments : list of str, optional`
 
         observatory_scoring_function : Callable, optional
             The scoring function to evaluate at observatories.

--- a/aas2rto/utils.py
+++ b/aas2rto/utils.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 import shutil
 import time
 import warnings
 from logging import getLogger
-from typing import List, Tuple, Union
 
 from pathlib import Path
 
@@ -138,7 +139,7 @@ def check_safe_to_query(
 
 def check_config_keys(
     provided, expected, name: str = None, warn=True
-) -> Tuple[List, List]:
+) -> tuple[list, list]:
     if isinstance(provided, dict):
         provided = provided.keys()
     if isinstance(expected, dict):
@@ -210,7 +211,7 @@ def check_missing_config_keys(
     return list(missing_keys)
 
 
-def get_observatory_name(observatory: Union[Observer, None, str]):
+def get_observatory_name(observatory: Observer | str | None):
     if isinstance(observatory, str):
         return observatory
     return observatory.name

--- a/aas2rto/utils.py
+++ b/aas2rto/utils.py
@@ -1,4 +1,5 @@
 import shutil
+import time
 import warnings
 from logging import getLogger
 from typing import List, Tuple, Union
@@ -99,6 +100,40 @@ def print_header(s: str) -> None:
     pad = max(pad, 1)
     fmt_s = "\n###" + "=" * pad + f" {s} " + "=" * pad + "###"
     print(fmt_s)
+
+
+def check_safe_to_query(
+    t_start: float = None,
+    failed_queries: int = None,
+    max_query_time: float = 60.0,
+    max_failed_queries: int = 10,
+):
+    """
+    Helper method - check if there have been to many failed queries, or if we're
+    querying for too long this loop.
+
+    Parameters
+    ----------
+    t_start: float, optional
+        if queries take longer than self.config["max_query_time"], return False
+        use the result of time.perf_counter()
+    failed_queries: int
+        if failed queries is
+    """
+
+    # Is it sensible to conitnue with queries, or is everything failing?
+    if failed_queries is not None:
+        if failed_queries >= max_failed_queries:
+            logger.warning(f"Too many failed queries ({failed_queries})")
+            return False
+
+    if t_start is not None:
+        t_elapsed = time.perf_counter() - t_start
+        if t_elapsed > max_query_time:
+            msg = f"queries taking too long ({t_elapsed:.1f}s > max {max_query_time:.1f}s)"
+            logger.warning(msg)
+            return False
+    return True
 
 
 def check_config_keys(

--- a/aas2rto/web/static_pages_manager.py
+++ b/aas2rto/web/static_pages_manager.py
@@ -367,9 +367,7 @@ class StaticPagesManager:
             if alt_id == target.target_id:
                 continue  # DON'T rewrite real page data with redirect - endless loop!
             template = self.web_environment.get_template("target_redirect.html")
-            redirect_url = (
-                f"../{self._get_target_page_url(alt_id)}"  # must be rel link...
-            )
+            redirect_url = f"../{self._get_target_page_url(target.target_id)}"  # REL!
             page_data = dict(
                 redirect_url=redirect_url,
                 target_id=target.target_id,

--- a/aas2rto/web/templates/target_redirect.html
+++ b/aas2rto/web/templates/target_redirect.html
@@ -1,4 +1,3 @@
-
 <html>
 <head>
     <title>Redirect...</title>

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ matplotlib
 numpy
 pandas
 pytest
+pytest-cov
 pyyaml
 scipy
 

--- a/test_aas2rto/conftest.py
+++ b/test_aas2rto/conftest.py
@@ -281,7 +281,7 @@ def lc_compiler():
 
 
 @pytest.fixture
-def lc_ztf(lc_pandas: pd.DataFrame):
+def ztf_lc(lc_pandas: pd.DataFrame):
     col_mapping = {
         "obs_id": "candid",
         "mag": "magpsf",
@@ -294,8 +294,8 @@ def lc_ztf(lc_pandas: pd.DataFrame):
 
 
 @pytest.fixture
-def ztf_td(lc_ztf: pd.DataFrame):
-    return TargetData(lightcurve=lc_ztf)
+def ztf_td(ztf_lc: pd.DataFrame):
+    return TargetData(lightcurve=ztf_lc)
 
 
 @pytest.fixture
@@ -310,6 +310,34 @@ def ztf_cutouts():
         "template": np.random.normal(0, 1.0, (20, 20)),
         "difference": np.random.normal(0, 1.0, (20, 20)),
     }
+
+
+@pytest.fixture
+def lsst_id0():
+    return 1234_5678_9000
+
+
+@pytest.fixture
+def lsst_rows(lsst_id0: int, t_fixed: Time):
+    return [
+        [lsst_id0 + 0, t_fixed.mjd + 0.0, 1000.0, 100.0, "g"],  # ~23.9+-0.1
+        [lsst_id0 + 1, t_fixed.mjd + 1.0, 2000.0, 200.0, "r"],  # ~23.1+-0.1
+        [lsst_id0 + 2, t_fixed.mjd + 2.0, 5000.0, 500.0, "i"],  # ~22.2+-0.1
+        [lsst_id0 + 3, t_fixed.mjd + 3.0, 10000.0, 100.0, "g"],  # ~21.4+-0.01
+        [lsst_id0 + 4, t_fixed.mjd + 4.0, 20000.0, 200.0, "r"],  # ~20.6+-0.01
+        [lsst_id0 + 5, t_fixed.mjd + 5.0, 50000.0, 500.0, "i"],  # ~19.7+-0.01
+    ]
+
+
+@pytest.fixture
+def lsst_lc(lsst_rows: list[list]):
+    col_names = "diaSourceId midpointMjdTai psfFlux psfFluxErr band".split()
+    return pd.DataFrame(lsst_rows, columns=col_names)
+
+
+@pytest.fixture
+def lsst_td(lsst_lc: pd.DataFrame):
+    return TargetData(lightcurve=lsst_lc)
 
 
 @pytest.fixture
@@ -331,14 +359,14 @@ def atlas_rows(t_fixed: Time):
 
 
 @pytest.fixture
-def lc_atlas(atlas_rows: List[List]):
-    colnames = "mjd m dm mag5sig F Obs".split()
-    return pd.DataFrame(atlas_rows, columns=colnames)
+def atlas_lc(atlas_rows: List[List]):
+    col_names = "mjd m dm mag5sig F Obs".split()
+    return pd.DataFrame(atlas_rows, columns=col_names)
 
 
 @pytest.fixture
-def atlas_td(lc_atlas: pd.DataFrame):
-    return TargetData(lightcurve=lc_atlas)
+def atlas_td(atlas_lc: pd.DataFrame):
+    return TargetData(lightcurve=atlas_lc)
 
 
 @pytest.fixture
@@ -647,6 +675,40 @@ def fink_config(fink_kafka_config: dict):
 
 
 @pytest.fixture
+def lasair_ztf_kafka_config():
+    topic_keys = {"lasair_id": "objectId", "ra": "ramean", "dec": "decmean"}
+    return {
+        "kafka_server": "lasair-blah.org",
+        "group_id": "test_group",
+        "topics": {
+            "cool_sne": topic_keys,
+        },
+    }
+
+
+@pytest.fixture
+def lasair_ztf_config(lasair_ztf_kafka_config: dict):
+    return {"kafka": lasair_ztf_kafka_config, "token": "example_token"}
+
+
+@pytest.fixture
+def lasair_lsst_kafka_config():
+    topic_keys = {"lasair_id": "diaObjectId", "ra": "ramean", "dec": "decmean"}
+    return {
+        "kafka_server": "lasair-blah.org",
+        "group_id": "test_group",
+        "topics": {
+            "cool_sne": topic_keys,
+        },
+    }
+
+
+@pytest.fixture
+def lasair_lsst_config(lasair_lsst_kafka_config: dict):
+    return {"kafka": lasair_lsst_kafka_config, "token": "example_token"}
+
+
+@pytest.fixture
 def atlas_credentials():
     return {"token": 1234}
 
@@ -694,11 +756,21 @@ def yse_config(yse_credentials: dict, yse_explorer_queries: dict):
 
 
 @pytest.fixture
-def global_qm_config(fink_config: dict, atlas_config: dict, tns_config: dict):
+def global_qm_config(
+    fink_config: dict,
+    lasair_ztf_config: dict,
+    lasair_lsst_config: dict,
+    atlas_config: dict,
+    yse_config: dict,
+    tns_config: dict,
+):
     # Deepcopy, else sub-dicts not modified correctly for tests of config-checkers.
     return {
         "fink_lsst": copy.deepcopy(fink_config),
         "fink_ztf": copy.deepcopy(fink_config),
+        "lasair_ztf": copy.deepcopy(lasair_ztf_config),
+        "lasair_lsst": copy.deepcopy(lasair_lsst_config),
         "atlas": copy.deepcopy(atlas_config),
+        "yse": copy.deepcopy(yse_config),
         "tns": copy.deepcopy(tns_config),
     }

--- a/test_aas2rto/conftest.py
+++ b/test_aas2rto/conftest.py
@@ -768,8 +768,8 @@ def global_qm_config(
     return {
         "fink_lsst": copy.deepcopy(fink_config),
         "fink_ztf": copy.deepcopy(fink_config),
-        "lasair_ztf": copy.deepcopy(lasair_ztf_config),
-        "lasair_lsst": copy.deepcopy(lasair_lsst_config),
+        # "lasair_ztf": copy.deepcopy(lasair_ztf_config),
+        # "lasair_lsst": copy.deepcopy(lasair_lsst_config),
         "atlas": copy.deepcopy(atlas_config),
         "yse": copy.deepcopy(yse_config),
         "tns": copy.deepcopy(tns_config),

--- a/test_aas2rto/unit/core/test__lightcurve_compilers.py
+++ b/test_aas2rto/unit/core/test__lightcurve_compilers.py
@@ -9,9 +9,10 @@ from astropy.time import Time
 
 from aas2rto.lightcurve_compilers import (
     DefaultLightcurveCompiler,
-    prepare_ztf_data,
-    prepare_yse_data,
     prepare_atlas_data,
+    prepare_lsst_data,
+    prepare_yse_data,
+    prepare_ztf_data,
 )
 from aas2rto.target import Target
 from aas2rto.target_data import TargetData
@@ -24,8 +25,33 @@ class Test__PrepZTF:
 
         # Assert
         assert isinstance(processed_ztf, pd.DataFrame)
-        exp_columns = "mjd mag magerr diffmaglim band tag candid source".split()
+        exp_columns = "mjd mag magerr diffmaglim band tag alert_id source".split()
         assert set(processed_ztf.columns) == set(exp_columns)
+
+
+class Test__PrepLSST:
+    def test__prep_lsst(self, lsst_td: TargetData):
+        # Act
+        processed_lsst = prepare_lsst_data(lsst_td)
+
+        # Assert
+        assert isinstance(processed_lsst, pd.DataFrame)
+        exp_columns = "mjd mag magerr diffmaglim band tag alert_id source".split()
+        assert set(processed_lsst.columns) == set(exp_columns)
+
+    def test__prep_lsst_tag(self, lsst_lc: TargetData):
+        # Arrange
+        tag_data = ["badqual", "badqual", "badqual", "valid", "valid", "valid"]
+        lsst_lc.loc[:, "tag"] = tag_data
+        td = TargetData(lightcurve=lsst_lc)
+
+        # Act
+        processed_lsst = prepare_lsst_data(td)
+
+        # Assert
+        print(processed_lsst[["tag", "alert_id", "mjd"]])
+        assert processed_lsst["tag"].iloc[2] == "badqual"
+        assert processed_lsst["tag"].iloc[3] == "valid"
 
 
 class Test__PrepAtlas:
@@ -35,7 +61,7 @@ class Test__PrepAtlas:
 
         # Assert
         assert isinstance(result, pd.DataFrame)
-        exp_columns = "mjd jd mag magerr diffmaglim tag band N_exp source".split()
+        exp_columns = "mjd mag magerr diffmaglim tag band N_exp source".split()
         set(result.columns) == set(exp_columns)
         assert len(result) == 5
 

--- a/test_aas2rto/unit/core/test__target_data.py
+++ b/test_aas2rto/unit/core/test__target_data.py
@@ -57,8 +57,8 @@ class Test__TargetDataInit:
         assert isinstance(td.meta, dict)
         assert len(td.meta) == 0
 
-        assert isinstance(td.probabilities, dict)
-        assert len(td.probabilities) == 0
+        # assert isinstance(td.probabilities, dict)
+        # assert len(td.probabilities) == 0
 
         assert isinstance(td.parameters, dict)
         assert len(td.parameters) == 0

--- a/test_aas2rto/unit/query_managers/conftest.py
+++ b/test_aas2rto/unit/query_managers/conftest.py
@@ -1,0 +1,61 @@
+import pytest
+
+import numpy as np
+
+from astropy.time import Time
+
+
+@pytest.fixture
+def mock_ztf_cutouts():
+    return dict(
+        cutoutScience=dict(stampData=np.random.normal(0.0, 0.1, (10, 10))),
+        cutoutDifference=dict(stampData=np.random.normal(0.0, 0.1, (10, 10))),
+        cutoutTemplate=dict(stampData=np.random.normal(0.0, 0.1, (10, 10))),
+    )
+
+
+@pytest.fixture
+def ztf_alert_base(fink_alert_extras: dict, mock_ztf_cutouts: dict, t_fixed: Time):
+    return {
+        "objectId": "ZTF00abc",  # the target_id
+        "candid": 0,  # the alert_id
+        "candidate": {
+            "ra": 180.0,
+            "dec": -30.0,
+            "jd": t_fixed.jd,
+            "magpsf": 20.0,
+            "sigpsf": 0.1,
+            "fid": 1,  # 1=ztf-g, 2=ztf-r
+        },
+        **mock_ztf_cutouts,
+    }
+
+
+@pytest.fixture
+def mock_lsst_cutouts():
+    return dict(
+        cutoutScience=np.random.normal(0.0, 0.1, (10, 10)),
+        cutoutDifference=np.random.normal(0.0, 0.1, (10, 10)),
+        cutoutTemplate=np.random.normal(0.0, 0.1, (10, 10)),
+    )
+
+
+@pytest.fixture
+def lsst_alert_base(mock_lsst_cutouts: dict, t_fixed: Time):
+    return {
+        "diaObject": {
+            "diaObjectId": 1000,
+            "ra": 180.0,
+            "dec": -30.0,
+            "nDiaSources": 2,  # Number of prev. detections
+        },
+        "diaSource": {
+            "diaSourceId": 1234,  # the alert_id
+            "ra": 180.0,
+            "dec": -30.0,
+            "psfFlux": 5000.0,  # approx mag 22.15
+            "psfFluxErr": 500.0,
+            "midpointMjdTai": t_fixed.mjd,
+            **mock_lsst_cutouts,
+        },
+    }

--- a/test_aas2rto/unit/query_managers/fink/conftest.py
+++ b/test_aas2rto/unit/query_managers/fink/conftest.py
@@ -1,15 +1,43 @@
+import gzip
+import io
 import pytest
+from typing import NoReturn
 
-# @pytest.fixture
-# def fink_kafka_config():
-#     return {
-#         "username": "user",
-#         "group.id": 1234,
-#         "bootstrap.servers": "http://fink.blah.org",
-#         "topics": ["cool_sne"],
-#     }
+import numpy as np
+
+from astropy.io import fits
 
 
-# @pytest.fixture
-# def fink_config(fink_kafka_config: dict):
-#     return {"kafka": fink_kafka_config, "fink_classes": "cool_sne"}
+@pytest.fixture
+def patch_fink_readstamp(monkeypatch: pytest.MonkeyPatch) -> NoReturn:
+
+    def mock_readstamp(data, return_type="array"):
+        return data
+
+    monkeypatch.setattr(
+        "aas2rto.query_managers.fink.fink_ztf.readstamp", mock_readstamp
+    )
+
+
+@pytest.fixture
+def fink_stamp_bytes() -> bytes:
+    data = np.arange(100).reshape(10, 10)
+    hdu = fits.PrimaryHDU(data=data)
+    stream = io.BytesIO()
+    hdu.writeto(stream)
+    stream.seek(0)
+    return gzip.compress(stream.read())
+
+
+@pytest.fixture
+def fink_alert_extras():
+    return {
+        "cdsxmatch": 1.0,
+        "rf_snia_vs_nonia": 1.0,
+        "snn_snia_vs_nonia": 1.0,
+        "snn_sn_vs_all": 1.0,
+        "mulens": 0.1,
+        "roid": 0.1,
+        "nalerthist": 4,
+        "rf_kn_vs_nonkn": 0.3,
+    }

--- a/test_aas2rto/unit/query_managers/fink/test__fink_base_qm.py
+++ b/test_aas2rto/unit/query_managers/fink/test__fink_base_qm.py
@@ -1,4 +1,5 @@
 import copy
+import gzip
 import json
 import pickle
 import pytest
@@ -13,18 +14,19 @@ import pandas as pd
 
 from astropy import units as u
 from astropy.coordinates import SkyCoord
+from astropy.io import fits
 from astropy.time import Time
 
 from fink_client.consumer import AlertConsumer
 
-from aas2rto.exc import UnexpectedKeysError, UnexpectedKeysWarning
+from aas2rto.exc import BadKafkaConfigError, UnexpectedKeysError, UnexpectedKeysWarning
 from aas2rto.query_managers.fink.fink_base import (
     FinkAlert,
-    BaseFinkQueryManager,
-    BadKafkaConfigError,
+    FinkBaseQueryManager,
     updates_from_classifier_queries,
+    readstamp,
 )
-from aas2rto.query_managers.fink.fink_portal_client import BaseFinkPortalClient
+from aas2rto.query_managers.fink.fink_portal_client import FinkBasePortalClient
 from aas2rto.target import Target
 from aas2rto.target_lookup import TargetLookup
 
@@ -40,10 +42,7 @@ def target_from_mock_alert(processed_alert: dict, t_ref: Time = None):
     return Target(target_id, coord, source="fink_cool", t_ref=t_ref)
 
 
-def process_single_mock_alert(
-    alert_data: FinkAlert,
-    t_ref: Time = None,
-):
+def process_single_mock_alert(alert_data: FinkAlert, t_ref: Time = None):
     topic, alert, key = alert_data
     processed_alert = copy.deepcopy(alert["candidate"])
     processed_alert["target_id"] = alert["target_id"]
@@ -52,28 +51,26 @@ def process_single_mock_alert(
     return processed_alert
 
 
-class MockFinkQuery:
+class MockFinkPortalClient:
     objects = None
     latests_query_and_collate = None
 
 
-class FinkExampleQM(BaseFinkQueryManager):
+class FinkExampleQM(FinkBaseQueryManager):
     name = "fink_cool"
     id_resolving_order = ("cool_survey", "fink_cool")
-    portal_client_class = MockFinkQuery
+    portal_client_class = MockFinkPortalClient  # NOT initialised here.
     target_id_key = "target_id"
     alert_id_key = "obs_id"
 
-    def add_target_from_alert(self, processed_alert: dict, t_ref: Time = None):
-        target_id = processed_alert["target_id"]
-        if target_id in self.target_lookup:
-            return None
-        target = target_from_mock_alert(processed_alert, t_ref=t_ref)
-        self.target_lookup.add_target(target)
-        return target
-
     def process_single_alert(self, alert_data: FinkAlert, t_ref=None):
         return process_single_mock_alert(alert_data, t_ref=t_ref)
+
+    def new_target_from_alert(self, processed_alert: dict, t_ref: Time = None):
+        return target_from_mock_alert(processed_alert, t_ref=t_ref)
+
+    def new_target_from_record(self, record: dict, t_ref: Time = None):
+        return target_from_mock_alert(record, t_ref=t_ref)
 
     def apply_updates_from_alert(self, processed_alert: dict, t_ref: Time = None):
         fink_id = processed_alert["target_id"]
@@ -81,16 +78,6 @@ class FinkExampleQM(BaseFinkQueryManager):
         target = self.target_lookup[fink_id]
         target.updated = True
         target.info_messages.append(f"{fink_id} alert with alert_id {alert_id}")
-
-    def add_target_from_record(self, record: dict):
-        fink_id = record["target_id"]
-        exising_target = self.target_lookup.get(fink_id, None)
-        if isinstance(exising_target, Target):
-            return None
-        coord = SkyCoord(record["ra"], record["dec"], unit="deg")
-        target = Target(fink_id, coord, source="cool_survey")
-        self.target_lookup.add_target(target)
-        return target
 
     def process_fink_lightcurve(self, unprocessed_lc: pd.DataFrame):
         unprocessed_lc.insert(0, "new_col", 100.0)
@@ -107,9 +94,7 @@ class FinkExampleQM(BaseFinkQueryManager):
 
     def load_cutouts_for_alert(self, fink_id: str, alert_id: int):
         cutouts_filepath = self.get_cutouts_filepath(fink_id, alert_id, mkdir=False)
-        print(cutouts_filepath)
         if cutouts_filepath.exists():
-            print("cutouts path exists!")
             with open(cutouts_filepath, "rb") as f:
                 cutouts = pickle.load(f)
             return cutouts
@@ -120,7 +105,7 @@ class BadPortalClient:
     pass
 
 
-class FinkBadQM(BaseFinkQueryManager):
+class FinkBadQM(FinkBaseQueryManager):
     name = "fink_fail"
     id_resolving_order = ("fail", "fink_fail")
     portal_client_class = BadPortalClient
@@ -307,6 +292,8 @@ class Test__HelperFunctions:
         assert alert[1]["obs_id"] == 1000
 
     def test__mock_poll(self, mock_alert_stream: AlertStream):
+        """Do I understand how python closures work?"""
+
         # Arrange
         def mock_poll():
             return next(mock_alert_stream)
@@ -319,7 +306,7 @@ class Test__HelperFunctions:
         assert len(alert) == 3
         assert alert[1]["target_id"] == "T101"  # etc.
 
-    def test__consumer_is_patched(self, patched_qm: BaseFinkQueryManager):
+    def test__consumer_is_patched(self, patched_qm: FinkBaseQueryManager):
         # Act
         with AlertConsumer(["cool_sne"], {}) as consumer:
             alert_data = consumer.poll()
@@ -328,38 +315,38 @@ class Test__HelperFunctions:
         assert isinstance(alert_data, tuple)
         assert alert_data[0] == "cool_sne"
 
-    def test__fq_objects_is_patched(self, patched_qm: BaseFinkQueryManager):
+    def test__fq_objects_is_patched(self, patched_qm: FinkBaseQueryManager):
         # Act
         lc = patched_qm.portal_client.objects(target_id="T00")
 
         # Assert
         assert len(lc) == 14  # etc.
 
-    def test__fq_objects_empty_for_bad_target(self, patched_qm: BaseFinkQueryManager):
+    def test__fq_objects_empty_for_bad_target(self, patched_qm: FinkBaseQueryManager):
         # Act
         lc = patched_qm.portal_client.objects(target_id="T01")
 
         # Assert
         assert len(lc) == 0
 
-    def test__fq_raise_on_request(self, patched_qm: BaseFinkQueryManager):
+    def test__fq_raise_on_request(self, patched_qm: FinkBaseQueryManager):
         # Act
         with pytest.raises(ValueError):
             lc = patched_qm.portal_client.objects(target_id="T_fail")
 
-    def test__fq_objects_no_target_id_raises(self, patched_qm: BaseFinkQueryManager):
+    def test__fq_objects_no_target_id_raises(self, patched_qm: FinkBaseQueryManager):
         # Act
         with pytest.raises(ValueError):
             lc = patched_qm.portal_client.objects()
 
-    def test__fq_latests_is_patched(self, patched_qm: BaseFinkQueryManager):
+    def test__fq_latests_is_patched(self, patched_qm: FinkBaseQueryManager):
         # Act
         results = patched_qm.portal_client.latests_query_and_collate(class_="cool_sne")
 
         # Assert
         assert len(results) == 3
 
-    def test__fq_latests_empty_for_bad_class(self, patched_qm: BaseFinkQueryManager):
+    def test__fq_latests_empty_for_bad_class(self, patched_qm: FinkBaseQueryManager):
         # Act
         results = patched_qm.portal_client.latests_query_and_collate(
             class_="boring_sne"
@@ -369,46 +356,46 @@ class Test__HelperFunctions:
         assert len(results) == 0
         assert set(results.columns) == set("target_id lastdate fink_class".split())
 
-    def test__fq_latests_missing_class_raises(self, patched_qm: BaseFinkQueryManager):
+    def test__fq_latests_empty_class_raises(self, patched_qm: FinkBaseQueryManager):
         # Act
         with pytest.raises(ValueError):
             lc = patched_qm.portal_client.latests_query_and_collate()
 
 
 class Test__ExampleQMFunctions:
-    def test__add_target_from_alert(
-        self, patched_qm: BaseFinkQueryManager, mock_alert_list: list, t_fixed: Time
+    def test__new_target_from_alert(
+        self, patched_qm: FinkBaseQueryManager, mock_alert_list: list, t_fixed: Time
     ):
         # Arrange
         processed_alert = process_single_mock_alert(mock_alert_list[0])
 
         # Act
-        target = patched_qm.add_target_from_alert(processed_alert)
+        target = patched_qm.new_target_from_alert(processed_alert)
 
         # Assert
         assert isinstance(target, Target)
 
-        assert set(patched_qm.target_lookup.keys()) == set(["T00", "T01", "T101"])
+        # assert set(patched_qm.target_lookup.keys()) == set(["T00", "T01", "T101"])
 
-    def test__no_add_existing_target(
-        self, patched_qm: BaseFinkQueryManager, mock_alert_list: list, t_fixed: Time
-    ):
-        # Arrange
-        processed_alert = process_single_mock_alert(mock_alert_list[0])
-        coord = SkyCoord(ra=120.0, dec=-60.0, unit="deg")
-        t101 = Target("T101", coord)  # different coord! to check alert not added
-        patched_qm.target_lookup.add_target(t101)
+    # def test__no_add_existing_target(
+    #     self, patched_qm: FinkBaseQueryManager, mock_alert_list: list, t_fixed: Time
+    # ):
+    #     # Arrange
+    #     processed_alert = process_single_mock_alert(mock_alert_list[0])
+    #     coord = SkyCoord(ra=120.0, dec=-60.0, unit="deg")
+    #     t101 = Target("T101", coord)  # different coord! to check alert not added
+    #     patched_qm.target_lookup.add_target(t101)
 
-        # Act
-        added_target = patched_qm.add_target_from_alert(processed_alert)
+    #     # Act
+    #     added_target = patched_qm.add_target_from_alert(processed_alert)
 
-        # Assert
-        assert added_target is None
+    #     # Assert
+    #     assert added_target is None
 
-        assert np.isclose(patched_qm.target_lookup["T101"].coord.ra.deg, 120.0)
+    #     assert np.isclose(patched_qm.target_lookup["T101"].coord.ra.deg, 120.0)
 
     def test__process_alerts(
-        self, patched_qm: BaseFinkQueryManager, mock_alert_list: list[FinkAlert]
+        self, patched_qm: FinkBaseQueryManager, mock_alert_list: list[FinkAlert]
     ):
         # Act
         processed_alert = patched_qm.process_single_alert(mock_alert_list[0])
@@ -502,21 +489,21 @@ class Test__KafkaConfig:
 
 
 class Test__PathMethods:
-    def test__lc_path(self, patched_qm: BaseFinkQueryManager, tmp_path: Path):
+    def test__lc_path(self, patched_qm: FinkBaseQueryManager, tmp_path: Path):
         # Act
         lc_path = patched_qm.get_lightcurve_filepath("test_id")
 
         # Assert
         assert lc_path == tmp_path / "fink_cool/lightcurves/test_id.csv"
 
-    def test__alert_path(self, patched_qm: BaseFinkQueryManager, tmp_path: Path):
+    def test__alert_path(self, patched_qm: FinkBaseQueryManager, tmp_path: Path):
         # Act
         lc_path = patched_qm.get_alert_filepath("test_id", "000")
 
         # Assert
         assert lc_path == tmp_path / "fink_cool/alerts/test_id/000.json"
 
-    def test__cutouts_path(self, patched_qm: BaseFinkQueryManager, tmp_path: Path):
+    def test__cutouts_path(self, patched_qm: FinkBaseQueryManager, tmp_path: Path):
         # Act
         lc_path = patched_qm.get_cutouts_filepath("test_id", "000")
 
@@ -524,73 +511,80 @@ class Test__PathMethods:
         assert lc_path == tmp_path / "fink_cool/cutouts/test_id/000.pkl"
 
 
-class Test__MissingFunctionsRaise:
-    # def test__no_id_resolving_order_raises(self, tlookup: TargetLookup, tmp_path: Path):
-    #     # Arrange
-    #     class NoIdOrderFinkQM(BaseFinkQueryManager):
-    #         name = "no_order"
-
-    #     # Act
-    #     with pytest.raises(NotImplementedError):
-    #         qm = NoIdOrderFinkQM({}, tlookup, parent_path=tmp_path)
-    # ==== test redundant - this is implemented with abstract base method
-
-    def test__no_target_from_alert_raises(
-        self, mock_alert_list: list, bad_qm: BaseFinkQueryManager
-    ):
-        # Arrange
-        alert = process_single_mock_alert(mock_alert_list[0])
-
+class Test__MissingAbstractMethodsRaises:
+    def test__missing(self):
         # Act
-        with pytest.raises(NotImplementedError):
-            bad_qm.add_target_from_alert(alert)
+        with pytest.raises(TypeError):
+            qm = FinkBadQM({}, {})  # OK this is just testing ABC methods.
 
-    def test__no_target_from_record_raises(
-        self, mock_alert_list: list, bad_qm: BaseFinkQueryManager, t_fixed: Time
-    ):
-        # Arrange
-        alert = process_single_mock_alert(mock_alert_list[0])
 
-        # Act
-        with pytest.raises(NotImplementedError):
-            bad_qm.add_target_from_record(alert)
+# class Test__MissingFunctionsRaise:
+#     # def test__no_id_resolving_order_raises(self, tlookup: TargetLookup, tmp_path: Path):
+#     #     # Arrange
+#     #     class NoIdOrderFinkQM(FinkBaseQueryManager):
+#     #         name = "no_order"
 
-    def test__no_apply_updates_raises(
-        self, mock_alert_list: list, bad_qm: BaseFinkQueryManager, t_fixed: Time
-    ):
-        # Arrange
-        alert = process_single_mock_alert(mock_alert_list[0])
-        target = target_from_mock_alert(alert, t_ref=t_fixed)
+#     #     # Act
+#     #     with pytest.raises(NotImplementedError):
+#     #         qm = NoIdOrderFinkQM({}, tlookup, parent_path=tmp_path)
+#     # ==== test redundant - this is implemented with abstract base method
 
-        # Act
-        with pytest.raises(NotImplementedError):
-            bad_qm.apply_updates_from_alert(alert)
+#     def test__no_target_from_alert_raises(
+#         self, mock_alert_list: list, bad_qm: FinkBaseQueryManager
+#     ):
+#         # Arrange
+#         alert = process_single_mock_alert(mock_alert_list[0])
 
-    def test__no_process_alert_raises(
-        self, mock_alert_list: list, bad_qm: BaseFinkQueryManager
-    ):
-        # Act
-        with pytest.raises(NotImplementedError):
-            bad_qm.process_single_alert(mock_alert_list[0])
+#         # Act
+#         with pytest.raises(NotImplementedError):
+#             bad_qm.new_target_from_alert(alert)
 
-    def test__no_process_fink_lc_raises(self, bad_qm: BaseFinkQueryManager):
-        # Act
-        with pytest.raises(NotImplementedError):
-            bad_qm.process_fink_lightcurve(pd.DataFrame(columns=["target_id"]))
+#     def test__no_target_from_record_raises(
+#         self, mock_alert_list: list, bad_qm: FinkBaseQueryManager, t_fixed: Time
+#     ):
+#         # Arrange
+#         alert = process_single_mock_alert(mock_alert_list[0])
 
-    def test__no_load_alerts_raises(self, bad_qm: BaseFinkQueryManager):
-        # Act
-        with pytest.raises(NotImplementedError):
-            bad_qm.load_missing_alerts_for_target("T00")
+#         # Act
+#         with pytest.raises(NotImplementedError):
+#             bad_qm.new_target_from_record(alert)
 
-    def test__no_load_cutouts_raises(self, bad_qm: BaseFinkQueryManager):
-        # Act
-        with pytest.raises(NotImplementedError):
-            bad_qm.load_cutouts_for_alert("T00", 1000)
+#     def test__no_apply_updates_raises(
+#         self, mock_alert_list: list, bad_qm: FinkBaseQueryManager, t_fixed: Time
+#     ):
+#         # Arrange
+#         alert = process_single_mock_alert(mock_alert_list[0])
+#         target = target_from_mock_alert(alert, t_ref=t_fixed)
+
+#         # Act
+#         with pytest.raises(NotImplementedError):
+#             bad_qm.apply_updates_from_alert(alert)
+
+#     def test__no_process_alert_raises(
+#         self, mock_alert_list: list, bad_qm: FinkBaseQueryManager
+#     ):
+#         # Act
+#         with pytest.raises(NotImplementedError):
+#             bad_qm.process_single_alert(mock_alert_list[0])
+
+#     def test__no_process_fink_lc_raises(self, bad_qm: FinkBaseQueryManager):
+#         # Act
+#         with pytest.raises(NotImplementedError):
+#             bad_qm.process_fink_lightcurve(pd.DataFrame(columns=["target_id"]))
+
+#     def test__no_load_alerts_raises(self, bad_qm: FinkBaseQueryManager):
+#         # Act
+#         with pytest.raises(NotImplementedError):
+#             bad_qm.load_missing_alerts_for_target("T00")
+
+#     def test__no_load_cutouts_raises(self, bad_qm: FinkBaseQueryManager):
+#         # Act
+#         with pytest.raises(NotImplementedError):
+#             bad_qm.load_cutouts_for_alert("T00", 1000)
 
 
 class Test__ListenForAlerts:
-    def test__listen_for_alerts(self, patched_qm: BaseFinkQueryManager, t_fixed: Time):
+    def test__listen_for_alerts(self, patched_qm: FinkBaseQueryManager, t_fixed: Time):
         # Act
         alerts = patched_qm.listen_for_alerts()
 
@@ -603,7 +597,7 @@ class Test__ListenForAlerts:
         assert alerts[0]["target_id"] == "T101"
         assert np.isclose(alerts[0]["mjd"] - 60000.0, 0.0)
 
-    def test__stop_after_nalerts(self, patched_qm: BaseFinkQueryManager):
+    def test__stop_after_nalerts(self, patched_qm: FinkBaseQueryManager):
         # Arrange
         patched_qm.config["n_alerts"] = 5
 
@@ -613,7 +607,7 @@ class Test__ListenForAlerts:
         # Assert
         assert len(alerts) == 5
 
-    def test__no_relevant_alerts_breaks(self, patched_qm: BaseFinkQueryManager):
+    def test__no_relevant_alerts_breaks(self, patched_qm: FinkBaseQueryManager):
         # Arrange
         patched_qm.kafka_config["topics"] = ["boring_sne"]
 
@@ -626,12 +620,12 @@ class Test__ListenForAlerts:
 
 
 class Test__TargetsFromAlerts:
-    def test__new_targets(self, patched_qm: BaseFinkQueryManager, t_fixed: Time):
+    def test__add_targets(self, patched_qm: FinkBaseQueryManager, t_fixed: Time):
         # Arrange
         processed_alerts = patched_qm.listen_for_alerts()
 
         # Act
-        new_targets = patched_qm.new_targets_from_alerts(
+        new_targets = patched_qm.add_targets_from_alerts(
             processed_alerts, t_ref=t_fixed
         )
 
@@ -639,7 +633,7 @@ class Test__TargetsFromAlerts:
         assert set(new_targets) == set(["T101"])
 
     def test__existing_targets_not_added(
-        self, patched_qm: BaseFinkQueryManager, t_fixed: Time
+        self, patched_qm: FinkBaseQueryManager, t_fixed: Time
     ):
         # Arrange
         processed_alerts = patched_qm.listen_for_alerts()
@@ -648,14 +642,14 @@ class Test__TargetsFromAlerts:
         patched_qm.target_lookup.add_target(t101)
 
         # Act
-        new_targets = patched_qm.new_targets_from_alerts(processed_alerts)
+        new_targets = patched_qm.add_targets_from_alerts(processed_alerts)
 
         # Assert
         assert set(new_targets) == set()
 
 
 class Test__ApplyUpdateMessages:
-    def test__apply_updates(self, patched_qm: BaseFinkQueryManager):
+    def test__apply_updates(self, patched_qm: FinkBaseQueryManager):
         # Arrange
         basic_alert = {"target_id": "T00", "obs_id": 100}
         assert not patched_qm.target_lookup["T00"].updated
@@ -671,7 +665,7 @@ class Test__ApplyUpdateMessages:
 
 
 class Test__GetFinkIdFromTarget:
-    def test__get_fink_id(self, patched_qm: BaseFinkQueryManager):
+    def test__get_fink_id(self, patched_qm: FinkBaseQueryManager):
         # Arrange
         target = Target("T901", SkyCoord(ra=0.0, dec=0.0, unit="deg"))
         target.alt_ids["cool_survey"] = "COOL_000"
@@ -679,18 +673,18 @@ class Test__GetFinkIdFromTarget:
         patched_qm.target_lookup.add_target(target)
 
         # Act
-        fink_id = patched_qm.get_fink_id_from_target(target)
+        fink_id = patched_qm.get_relevant_id_from_target(target)
 
         # Assert
         assert fink_id == "COOL_000"
 
-    def test__none_from_no_alt_id(self, patched_qm: BaseFinkQueryManager):
+    def test__none_from_no_alt_id(self, patched_qm: FinkBaseQueryManager):
         # Arrange
-        target = Target("T901", SkyCoord(ra=0.0, dec=0.0, unit="deg"))
+        target = Target("T901", SkyCoord(ra=0.0, dec=0.0, unit="deg"))  # "cool_id" set
         patched_qm.target_lookup.add_target(target)
 
         # Act
-        fink_id = patched_qm.get_fink_id_from_target(target)
+        fink_id = patched_qm.get_relevant_id_from_target(target)  # "cool_id" requied
 
         # Assert
         assert fink_id is None
@@ -752,7 +746,7 @@ class Test__UpdatesFromClassifierQueries:
 
 
 class Test__FinkClassifierQueries:
-    def test__no_existing(self, patched_qm: BaseFinkQueryManager):
+    def test__no_existing(self, patched_qm: FinkBaseQueryManager):
         # Act
         updates = patched_qm.fink_classifier_queries()
 
@@ -779,7 +773,7 @@ class Test__FinkClassifierQueries:
 
     def test__with_existing(
         self,
-        patched_qm: BaseFinkQueryManager,
+        patched_qm: FinkBaseQueryManager,
         mock_existing_classifier_results: pd.DataFrame,
     ):
         # Arrange
@@ -812,7 +806,7 @@ class Test__FinkClassifierQueries:
 
     def test__skip_recent_query(
         self,
-        patched_qm: BaseFinkQueryManager,
+        patched_qm: FinkBaseQueryManager,
         mock_existing_classifier_results: pd.DataFrame,
     ):
         # Arrange
@@ -826,7 +820,7 @@ class Test__FinkClassifierQueries:
         # Assert
         assert len(updates) == 0
 
-    def test__no_results_writes_empty_file(self, patched_qm: BaseFinkQueryManager):
+    def test__no_results_writes_empty_file(self, patched_qm: FinkBaseQueryManager):
         # Arrange
         patched_qm.config["fink_classes"] = ["boring_sne"]
 
@@ -844,12 +838,12 @@ class Test__FinkClassifierQueries:
 
 
 class Test__NewTargetsFromQueryRecords:
-    def test__new_targets(self, patched_qm: BaseFinkQueryManager):
+    def test__add_targets(self, patched_qm: FinkBaseQueryManager):
         # Arrange
         query_records = patched_qm.fink_classifier_queries()
 
         # Act
-        new_targets = patched_qm.new_targets_from_query_records(query_records)
+        new_targets = patched_qm.add_targets_from_query_records(query_records)
 
         # Assert
         assert set(new_targets) == set(["T201", "T202", "T203"])
@@ -860,20 +854,20 @@ class Test__NewTargetsFromQueryRecords:
 
 class Test__GetLCsToQuery:
     def test__skip_recent(
-        self, patched_qm: BaseFinkQueryManager, lc_fink: pd.DataFrame
+        self, patched_qm: FinkBaseQueryManager, lc_fink: pd.DataFrame
     ):
         # Arrange
         lc_filepath = patched_qm.get_lightcurve_filepath("T00")
         lc_fink.to_csv(lc_filepath, index=False)
 
         # Act
-        to_query = patched_qm.get_lightcurves_to_query()
+        to_query = patched_qm.select_lightcurves_to_query()
 
         # Assert
         assert set(to_query) == set(["T01"])
 
     def test__include_old(
-        self, patched_qm: BaseFinkQueryManager, lc_fink: pd.DataFrame
+        self, patched_qm: FinkBaseQueryManager, lc_fink: pd.DataFrame
     ):
         # Arrange
         lc_filepath = patched_qm.get_lightcurve_filepath("T00")
@@ -882,20 +876,20 @@ class Test__GetLCsToQuery:
         patched_qm.config["lightcurve_update_interval"] = 1.0
 
         # Act
-        to_query = patched_qm.get_lightcurves_to_query(t_ref=t_future)
+        to_query = patched_qm.select_lightcurves_to_query(t_ref=t_future)
 
         # Assert
         assert set(to_query) == set(["T00", "T01"])
 
 
 class Test__QueryLCs:
-    def test__query_all(self, patched_qm: BaseFinkQueryManager):
+    def test__query_all(self, patched_qm: FinkBaseQueryManager):
         # Act
-        success, missing, failed = patched_qm.query_lightcurves()
+        success, empty, failed = patched_qm.query_lightcurves()
 
         # Assert
         assert set(success) == set(["T00"])
-        assert set(missing) == set(["T01"])
+        assert set(empty) == set(["T01"])
         assert set(failed) == set()
 
         exp_lc_file = patched_qm.get_lightcurve_filepath("T00")
@@ -905,46 +899,46 @@ class Test__QueryLCs:
         assert len(loaded_lc) == 14
         assert "new_col" in loaded_lc.columns  # processing func is correctly called.
 
-    def test__failing_queries_no_raise(self, patched_qm: BaseFinkQueryManager):
+    def test__failing_queries_no_raise(self, patched_qm: FinkBaseQueryManager):
         # Arrange
         patched_qm.config["lightcurve_chunk_size"] = 1
 
         # Act
-        success, missing, failed = patched_qm.query_lightcurves(
+        success, empty, failed = patched_qm.query_lightcurves(
             fink_id_list=["T00", "T_fail"]
         )
 
         # Assert
         assert set(success) == set(["T00"])
-        assert set(missing) == set()
+        assert set(empty) == set()
         assert set(failed) == set(["T_fail"])
 
-    def test__all_missing_counted(self, patched_qm: BaseFinkQueryManager):
+    def test__all_empty_counted(self, patched_qm: FinkBaseQueryManager):
         # Act
-        success, missing, failed = patched_qm.query_lightcurves(
+        success, empty, failed = patched_qm.query_lightcurves(
             fink_id_list=["T01", "T02", "T03"]
         )
 
         # Assert
-        len(missing) == 3
-        set(missing) == set(["T01", "T02", "T03"])
+        len(empty) == 3
+        set(empty) == set(["T01", "T02", "T03"])
 
-    def test__quit_after_n_failed(self, patched_qm: BaseFinkQueryManager):
+    def test__quit_after_n_failed(self, patched_qm: FinkBaseQueryManager):
         # Arrange
         patched_qm.config["lightcurve_chunk_size"] = 1
         patched_qm.config["max_failed_queries"] = 3
         id_list = "T_fail_01 T_fail_02 T_fail_03 T_fail_04 T_fail_05".split()
 
         # Act
-        success, missing, failed = patched_qm.query_lightcurves(fink_id_list=id_list)
+        success, empty, failed = patched_qm.query_lightcurves(fink_id_list=id_list)
 
         # Assert
         assert set(success) == set()
-        assert set(missing) == set()
+        assert set(empty) == set()
         assert len(failed) == 3
         assert set(failed) == set(["T_fail_01", "T_fail_02", "T_fail_03"])
 
-    def test__quit_after_slow_query(self, patched_qm: BaseFinkQueryManager):
+    def test__quit_after_slow_query(self, patched_qm: FinkBaseQueryManager):
         # Arrange
         t_start = time.perf_counter()
         _, _, _ = patched_qm.query_lightcurves(fink_id_list=["T00"])
@@ -954,15 +948,15 @@ class Test__QueryLCs:
         patched_qm.config["max_query_time"] = 0.3
 
         # Act
-        success, missing, failed = patched_qm.query_lightcurves(
+        success, empty, failed = patched_qm.query_lightcurves(
             fink_id_list=["T_sleep", "T01"]
         )
 
         # Assert
-        assert set(missing) == set(["T_sleep"])
+        assert set(empty) == set(["T_sleep"])
         # didn't make it to T01 -- quit after 0.3 sec
 
-    def test__bulk_query(self, patched_qm: BaseFinkQueryManager, tmp_path: Path):
+    def test__bulk_query(self, patched_qm: FinkBaseQueryManager, tmp_path: Path):
         # Arrange
         bulk_filepath = tmp_path / "bulk_lcs.csv"
         patched_qm.config["lightcurve_chunk_size"] = 1
@@ -975,7 +969,7 @@ class Test__QueryLCs:
         loaded_lc = pd.read_csv(bulk_filepath)
         assert len(loaded_lc) == 14
 
-    def test__bulk_query_empty(self, patched_qm: BaseFinkQueryManager, tmp_path: Path):
+    def test__bulk_query_empty(self, patched_qm: FinkBaseQueryManager, tmp_path: Path):
         # Arrange
         bulk_filepath = tmp_path / "bulk_lcs.csv"
         patched_qm.config["lightcurve_chunk_size"] = 1
@@ -989,8 +983,56 @@ class Test__QueryLCs:
         assert set(loaded_lc.columns) == set(["target_id", "obs_id", "mjd"])
 
 
+class Test__LoadSingleLC:
+    def test__load_lc(self, patched_qm: FinkBaseQueryManager, lc_pandas: pd.DataFrame):
+        # Arrange
+        lc_filepath = patched_qm.get_lightcurve_filepath("T00")
+        lc_pandas.to_csv(lc_filepath, index=False)
+
+        # Act
+        loaded = patched_qm.load_single_lightcurve(target_id="T00")
+
+        # Assert
+        assert isinstance(loaded, pd.DataFrame)
+
+    def test__missing_no_fail(
+        self, patched_qm: FinkBaseQueryManager, lc_pandas: pd.DataFrame
+    ):
+        # Act
+        lc = patched_qm.load_single_lightcurve(target_id="T01")
+
+        # Assert
+        assert lc is None
+
+    def test__no_relevant_id(
+        self, patched_qm: FinkBaseQueryManager, lc_pandas: pd.DataFrame
+    ):
+        # Arrange
+        T01 = patched_qm.target_lookup["T01"]
+        T01.alt_ids.pop("cool_survey")
+        assert patched_qm.get_relevant_id_from_target(T01) is None
+
+        # Act
+        lc = patched_qm.load_single_lightcurve("T01")
+
+        # Assert
+        assert lc is None
+
+    def test__bad_target_no_error(
+        self, patched_qm: FinkBaseQueryManager, lc_pandas: pd.DataFrame
+    ):
+        # Arrange
+        assert "T02" not in patched_qm.target_lookup
+
+        # Act
+        lc = patched_qm.load_single_lightcurve("T02")
+
+        # Assert
+        assert lc is None
+
+
 class Test__IntegrateAlerts:
-    def test__no_existing_lc(self, patched_qm: BaseFinkQueryManager):
+    def test__no_existing_lc(self, patched_qm: FinkBaseQueryManager):
         # this is a very simple test, as all the logic should be in the subclass...
         # Act
         modified_targets = patched_qm.integrate_alerts()
@@ -1001,7 +1043,7 @@ class Test__IntegrateAlerts:
 
 class Test__LoadCutouts:
     def test__load_cutouts(
-        self, patched_qm: BaseFinkQueryManager, lc_pandas: pd.DataFrame
+        self, patched_qm: FinkBaseQueryManager, lc_pandas: pd.DataFrame
     ):
         # Arrange
         T00 = patched_qm.target_lookup["T00"]
@@ -1017,18 +1059,18 @@ class Test__LoadCutouts:
         T00_fink_data.add_lightcurve(lc_pandas)
 
         # Act
-        loaded, missing, skipped = patched_qm.load_cutouts()
+        loaded, empty, skipped = patched_qm.load_cutouts()
 
         # Assert
         assert set(loaded) == set(["T00"])
-        assert set(missing) == set()  # T01 does not have a fink_id, so ignore
+        assert set(empty) == set()  # T01 does not have a fink_id, so ignore
         assert set(skipped) == set()
 
         assert T00_fink_data.meta["cutouts_alert_id"] == 1000_2000_3000_4002
         assert set(T00_fink_data.cutouts.keys()) == set(["science"])
         assert T00_fink_data.cutouts["science"] == 200
 
-    def test__skip_no_target_data(self, patched_qm: BaseFinkQueryManager):
+    def test__skip_no_target_data(self, patched_qm: FinkBaseQueryManager):
         # Arrange
         T00 = patched_qm.target_lookup["T00"]
         T00.alt_ids["fink_cool"] = "T00"
@@ -1037,15 +1079,15 @@ class Test__LoadCutouts:
             pickle.dump(dict(science=1.0), f)
 
         # Act
-        loaded, missing, skipped = patched_qm.load_cutouts()
+        loaded, empty, skipped = patched_qm.load_cutouts()
 
         # Assert
         assert set(loaded) == set()
-        assert set(missing) == set()
+        assert set(empty) == set()
         assert set(skipped) == set()
 
     def test__skip_if_latest_loaded(
-        self, patched_qm: BaseFinkQueryManager, lc_pandas: pd.DataFrame
+        self, patched_qm: FinkBaseQueryManager, lc_pandas: pd.DataFrame
     ):
         # Arrange
         T00 = patched_qm.target_lookup["T00"]
@@ -1060,16 +1102,16 @@ class Test__LoadCutouts:
         patched_qm.load_cutouts()
 
         # Act
-        loaded, missing, skipped = patched_qm.load_cutouts()
+        loaded, empty, skipped = patched_qm.load_cutouts()
 
         # Assert
         assert set(loaded) == set()
-        assert set(missing) == set()
+        assert set(empty) == set()
         assert set(skipped) == set(["T00"])
 
 
 class Test__PerformAllTasks:
-    def test__startup(self, patched_qm: BaseFinkQueryManager, t_fixed: Time):
+    def test__startup(self, patched_qm: FinkBaseQueryManager, t_fixed: Time):
         # Act
         patched_qm.perform_all_tasks(iteration=0, t_ref=t_fixed)
 
@@ -1081,10 +1123,33 @@ class Test__PerformAllTasks:
         T01 = patched_qm.target_lookup["T01"]
         assert set(T01.info_messages) == set(["alerts integrated!"])
 
-    def test__non_startup(self, patched_qm: BaseFinkQueryManager, t_fixed: Time):
+    def test__non_startup(self, patched_qm: FinkBaseQueryManager, t_fixed: Time):
         # Act
         patched_qm.perform_all_tasks(-1, t_ref=t_fixed)
 
         # Assert
         exp_targets = "T00 T01 T101 T201 T202 T203".split()
         assert set(patched_qm.target_lookup.keys()) == set(exp_targets)
+
+
+class Test__Readstamp:
+    def test__readstamp(self, fink_stamp_bytes: bytes):
+        # Act
+        recovered = readstamp(fink_stamp_bytes, gzipped=True)
+        # gzipped is True BY DEFAULT - but explict is helpful reminder here...
+
+        # Assert
+        assert isinstance(recovered, np.ndarray)
+
+        assert recovered.shape == (10, 10)
+
+    def test__readstamp_gzipped(self, fink_stamp_bytes: bytes):
+        # Arrange
+        decompressed_stamp = gzip.decompress(fink_stamp_bytes)
+
+        # Act
+        recovered = readstamp(decompressed_stamp, gzipped=False)
+
+        # Assert
+        assert isinstance(recovered, np.ndarray)
+        assert recovered.shape == (10, 10)

--- a/test_aas2rto/unit/query_managers/fink/test__fink_lsst_qm.py
+++ b/test_aas2rto/unit/query_managers/fink/test__fink_lsst_qm.py
@@ -1,0 +1,225 @@
+import copy
+import pytest
+from pathlib import Path
+from typing import NoReturn
+
+import numpy as np
+
+import pandas as pd
+
+from astropy import units as u
+from astropy.time import Time
+
+from aas2rto.query_managers.fink.fink_base import FinkAlert, EXTRA_FINK_ALERT_KEYS
+from aas2rto.query_managers.fink.fink_lsst import (
+    FinkLSSTQueryManager,
+    process_fink_lsst_alert,
+    target_from_fink_lsst_alert,
+    apply_fink_lsst_updates_to_target,
+    process_fink_lsst_lightcurve,
+)
+from aas2rto.target import Target
+from aas2rto.target_lookup import TargetLookup
+
+
+@pytest.fixture
+def mock_cutouts():
+    return dict(
+        cutoutScience=dict(stampData=np.random.normal(0.0, 0.1, (10, 10))),
+        cutoutDifference=dict(stampData=np.random.normal(0.0, 0.1, (10, 10))),
+        cutoutTemplate=dict(stampData=np.random.normal(0.0, 0.1, (10, 10))),
+    )
+
+
+@pytest.fixture
+def fink_lsst_alert_list(
+    lsst_alert_base: dict, t_fixed: Time, fink_alert_extras: dict
+) -> list[FinkAlert]:
+
+    lsst_filters = "g r i".split()
+
+    alert_data_list = []
+    for ii in range(5):
+        alert = copy.deepcopy(lsst_alert_base)
+
+        alert["diaSource"]["midpointMjdTai"] = t_fixed.mjd + ii
+        alert["diaSource"]["psfFlux"] = 10 ** (-0.4 * ((22.0 - ii * 0.5) - 31.4))
+        alert["diaSource"]["psfFluxErr"] = alert["diaSource"]["psfFlux"] / 10.0
+        alert["diaSource"]["band"] = lsst_filters[ii % 3]
+
+        alert.update(copy.deepcopy(fink_alert_extras))
+
+        alert_data = ("lsst_cool_sne", alert, "schema_string")
+        alert_data_list.append(alert_data)
+    return alert_data_list
+
+
+@pytest.fixture
+def patch_readstamp(monkeypatch: pytest.MonkeyPatch) -> NoReturn:
+
+    def mock_readstamp(data, return_array="array"):
+        return data
+
+    monkeypatch.setattr(
+        "aas2rto.query_managers.fink.fink_lsst.readstamp", mock_readstamp
+    )
+
+
+@pytest.fixture
+def patched_lsst_qm(
+    fink_config: dict, tlookup: TargetLookup, tmp_path: Path, patch_readstamp: NoReturn
+):
+    qm = FinkLSSTQueryManager(fink_config, tlookup, parent_path=tmp_path)
+    return qm
+
+
+@pytest.fixture
+def processed_lsst_alert_list(
+    patched_lsst_qm: FinkLSSTQueryManager,
+    fink_lsst_alert_list: list[FinkAlert],
+    tmp_path: Path,
+) -> list[dict]:
+    processed_alerts = []
+    alert_dir = tmp_path / "fink_lsst/alerts/1000"
+    cutouts_dir = tmp_path / "fink_lsst/cutouts/1000"
+    for alert_data in fink_lsst_alert_list:
+        processed_alert = patched_lsst_qm.process_single_alert(alert_data)
+        processed_alerts.append(processed_alert)
+
+        # Ensure alerts are dumped...
+        alert_id = processed_alert["diaSourceId"]
+        alert_path = alert_dir / f"{alert_id}.json"
+        assert alert_path.exists()
+        cutouts_path = cutouts_dir / f"{alert_id}.pkl"
+        assert cutouts_path.exists()
+    return processed_alerts
+
+
+@pytest.fixture
+def unprocessed_lsst_lc(lsst_lc: pd.DataFrame):
+    lc = lsst_lc.copy()
+    return lc
+
+
+##===== Tests start here! =====##
+
+
+class Test__ProcessLSSTAlert:
+
+    @pytest.fixture
+    def lsst_alert_data(
+        self, lsst_alert_base: dict, fink_alert_extras: dict
+    ) -> FinkAlert:
+        # Arrange
+        alert = copy.deepcopy(lsst_alert_base)
+        alert.update(fink_alert_extras)
+        return ("some_topic", alert, "some_schema")
+
+    def test__process_lsst_alert(
+        self, lsst_alert_data: FinkAlert, patch_readstamp: NoReturn
+    ):
+
+        # Act
+        proc_alert = process_fink_lsst_alert(lsst_alert_data)
+
+        # Assert
+        candidate_keys = (
+            "diaObjectId ra dec diaSourceId midpointMjdTai psfFlux psfFluxErr".split()
+        )
+        cutout_keys = [f"cutout{x}" for x in "Science Difference Template".split()]
+
+        assert all([k in proc_alert.keys() for k in candidate_keys])
+        assert all([k in proc_alert.keys() for k in EXTRA_FINK_ALERT_KEYS])  # copied
+        # cutout removed before JSON!
+        assert all([k not in proc_alert.keys() for k in cutout_keys])
+
+        # Cutouts are removed from alert in order to json!
+        assert "topic" in proc_alert
+        assert "diaSource" not in proc_alert.keys()  # flattened.
+
+    def test__write_alert_data(
+        self, lsst_alert_data: FinkAlert, patch_readstamp: NoReturn, tmp_path: Path
+    ):
+        # Arrange
+        alert_path = tmp_path / "alert.json"
+        cutouts_path = tmp_path / "cutouts.pkl"
+
+        # Act
+        proc_alert = process_fink_lsst_alert(
+            lsst_alert_data, alert_filepath=alert_path, cutouts_filepath=cutouts_path
+        )
+
+        # Assert
+        assert alert_path.exists()
+        assert cutouts_path.exists()
+
+
+class Test__TargetFromAlert:
+    def test__target_from_alert(self, processed_lsst_alert_list: list[dict]):
+        # Arrange
+        processed_alert = processed_lsst_alert_list[0]
+
+        # Act
+        target = target_from_fink_lsst_alert(processed_alert)
+
+        # Assert
+        assert isinstance(target, Target)
+        assert isinstance(target.target_id, str)  # int diaObjectId converted!
+        assert target.target_id == "1000"
+
+        assert set(target.alt_ids.keys()) == set(["lsst", "fink_lsst"])
+
+    def test__target_is_added(
+        self,
+        processed_lsst_alert_list: list[dict],
+        patched_lsst_qm: FinkLSSTQueryManager,
+    ):
+        # Arrange
+        processed_alert = processed_lsst_alert_list[0]
+
+        # Act
+        targets_added = patched_lsst_qm.add_targets_from_alerts([processed_alert])
+
+        # Assert
+        assert set(targets_added) == set(["1000"])
+
+        assert "1000" in patched_lsst_qm.target_lookup
+
+    def test__target_(self):
+        pass
+
+
+class Test__ApplyUpdatesFromAlert:
+    def test__apply_updates_to_target(
+        self,
+        processed_lsst_alert_list: list[dict],
+    ):
+        # Arrange
+        processed_alert = processed_lsst_alert_list[0]
+        t_1000 = target_from_fink_lsst_alert(processed_alert)
+
+        # Act
+        apply_fink_lsst_updates_to_target(t_1000, processed_alert)
+
+        # Assert
+        assert t_1000.updated
+
+        assert len(t_1000.info_messages) == 1
+        assert t_1000.info_messages[0].startswith("New FINK-LSST")
+
+    def test__use_qm_function(
+        self, processed_lsst_alert_list: list, patched_lsst_qm: FinkLSSTQueryManager
+    ):
+        # Arrange
+        processed_alert = processed_lsst_alert_list[0]
+        patched_lsst_qm.add_targets_from_alerts([processed_alert])
+
+        # Act
+        patched_lsst_qm.update_info_messages([processed_alert])
+
+
+# class Test__ProcessLSSTLightcurve:
+#     def test__process_lightcurve(
+#         self,
+#     ):
+#         pass

--- a/test_aas2rto/unit/query_managers/fink/test__fink_portal_clients.py
+++ b/test_aas2rto/unit/query_managers/fink/test__fink_portal_clients.py
@@ -8,7 +8,7 @@ from astropy.table import Table
 from astropy.time import Time
 
 from aas2rto.query_managers.fink.fink_portal_client import (
-    BaseFinkPortalClient,
+    FinkBasePortalClient,
     FinkZTFPortalClient,
     FinkLSSTPortalClient,
     FinkPortalClientError,
@@ -17,14 +17,15 @@ from aas2rto.query_managers.fink.fink_portal_client import (
 ##===== Some helper functions here =====##
 
 
-class FinkCoolPortalClient(BaseFinkPortalClient):
+class FinkCoolPortalClient(FinkBasePortalClient):
+    # DON'T use api.cool.fink-portal.org, so no chance of traffic to fink-portal.org
     api_url = "https://fink_cool.org/api/v1"
     imtypes = ("Difference", "Template")
     id_key = "target_id"
 
 
-class FinkBadQuery(FinkPortalClientError):
-    pass
+# class FinkBadQuery(FinkPortalClientError):
+#     pass
 
 
 class MockElapsed:

--- a/test_aas2rto/unit/query_managers/fink/test__fink_ztf_qm.py
+++ b/test_aas2rto/unit/query_managers/fink/test__fink_ztf_qm.py
@@ -11,7 +11,7 @@ import pandas as pd
 from astropy import units as u
 from astropy.time import Time
 
-from aas2rto.query_managers.fink.fink_base import FinkAlert, FinkBaseQueryManager
+from aas2rto.query_managers.fink.fink_base import FinkAlert, BaseFinkQueryManager
 from aas2rto.query_managers.fink.fink_ztf import (
     FinkZTFQueryManager,
     process_ztf_alert,
@@ -363,5 +363,5 @@ class Test__FinkZTFQMInit:
         qm = FinkZTFQueryManager({}, tlookup, parent_path=tmp_path)
 
         # Assert
-        assert isinstance(qm, FinkBaseQueryManager)
+        assert isinstance(qm, BaseFinkQueryManager)
         assert hasattr(qm, "config")  # OK this is now just testing subclassing...

--- a/test_aas2rto/unit/query_managers/test__base_qm.py
+++ b/test_aas2rto/unit/query_managers/test__base_qm.py
@@ -4,18 +4,24 @@ from pathlib import Path
 import pandas as pd
 
 from astropy import units as u
+from astropy.coordinates import SkyCoord
 from astropy.time import Time
 
 from aas2rto import paths
 from aas2rto.exc import UnknownTargetWarning
-from aas2rto.query_managers.base import BaseQueryManager
+from aas2rto.query_managers.base import (
+    BaseQueryManager,
+    LightcurveQueryManager,
+    KafkaQueryManager,
+)
+from aas2rto.target import Target
 from aas2rto.target_lookup import TargetLookup
 
 
 class NoNameQM(BaseQueryManager):
 
-    def __init__(self, target_lookup: TargetLookup):
-        self.target_lookup = target_lookup
+    def __init__(self, config: dict, target_lookup: TargetLookup):
+        pass
 
     def perform_all_tasks(self):
         pass
@@ -24,19 +30,19 @@ class NoNameQM(BaseQueryManager):
 class NoPerformTasksQM(BaseQueryManager):
     name = "no_perform_tasks"
 
-    def __init__(self, target_lookup: TargetLookup):
-        self.target_lookup = target_lookup
+    def __init__(self, config: dict, target_lookup: TargetLookup):
+        pass
 
 
 class CoolQM(BaseQueryManager):
     name = "cool"
 
-    def __init__(
-        self, config: dict, target_lookup: TargetLookup, parent_path: Path = None
-    ):
-        self.config = config
-        self.target_lookup = target_lookup
-        # do NOT process paths here
+    # def __init__(
+    #     self, config: dict, target_lookup: TargetLookup, parent_path: Path = None
+    # ):
+    #     self.config = config
+    #     self.target_lookup = target_lookup
+    #     # do NOT process paths here
 
     def perform_all_tasks(self, iteration: int, t_ref: Time = None):
         pass
@@ -45,22 +51,115 @@ class CoolQM(BaseQueryManager):
     #    return
 
 
+class CoolLightcurveQM(LightcurveQueryManager):
+    name = "cool_lc"
+    id_resolving_order = ("src01", "src02")
+
+    # def __init__(
+    #     self, config: dict, target_lookup: TargetLookup, parent_path: Path = None
+    # ):
+    #     self.config = config
+    #     self.target_lookup = target_lookup
+    #     # do NOT process paths here
+
+    def get_lightcurve_filepath(self, id_: str):
+        pass  # Must implement, else init fails with ABC - see load_single_lightcurve...
+
+    def load_single_lightcurve(self, target_id, t_ref=None):
+        pass  # Must implement, else init fails with ABC error - patch in fixture...
+
+    def perform_all_tasks(self, iteration: int, t_ref: Time = None):
+        pass
+
+
+class BadLCQM(LightcurveQueryManager):
+    name = "bad_lc"
+
+    def __init__(
+        self, config: dict, target_lookup: TargetLookup, parent_path: Path = None
+    ):
+        pass
+
+    def perform_all_tasks(self, iteration: int, t_ref: Time = None):
+        pass
+
+
+class CoolKafkaQM(KafkaQueryManager):
+    name = "cool_kafka"
+    target_id_key = "target_id"
+
+    # def __init__(
+    #     self, config: dict, target_lookup: TargetLookup, parent_path: Path = None
+    # ):
+    #     self.config = config
+    #     self.target_lookup = target_lookup
+    #     # do NOT process paths here
+
+    def listen_for_alerts(self):
+        pass
+
+    def new_target_from_alert(self, processed_alert, t_ref=None):
+        target_id = processed_alert["target_id"]
+        coord = SkyCoord(processed_alert["ra"], processed_alert["dec"], unit=u.deg)
+        return Target(target_id, coord)
+
+    def perform_all_tasks(self, iteration: int, t_ref: Time = None):
+        pass
+
+
 ##===== Fixtures =====##
 
 
 @pytest.fixture
-def cool_qm(
-    lc_ztf: pd.DataFrame, tlookup: TargetLookup, monkeypatch: pytest.MonkeyPatch
+def cool_qm(tlookup: TargetLookup, tmp_path: Path):
+    return CoolQM({}, tlookup, tmp_path)
+
+
+@pytest.fixture
+def cool_lc_qm(
+    ztf_lc: pd.DataFrame,
+    tlookup: TargetLookup,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ):
     def mock_load_lc(target_id: str, t_ref=None):
         if target_id == "T00":
-            return lc_ztf
+            return ztf_lc
         if target_id == "T01":
             return pd.DataFrame(columns="mjd mag magerr tag".split())
         return None
 
-    qm = CoolQM({}, tlookup)
+    qm = CoolLightcurveQM({}, tlookup, tmp_path)
     monkeypatch.setattr(qm, "load_single_lightcurve", mock_load_lc)
+    return qm
+
+
+@pytest.fixture
+def mock_alert_list(t_fixed: Time) -> list[dict]:
+    alert_list = []
+    for ii in range(5):
+        alert = {
+            "target_id": f"T{101 + ii}",  # T101, T102, ...
+            "ra": 30.0 + ii * 30.0,  # 30.0, 60.0, 90.0, 120.0, 150.0
+            "dec": -45.0,
+        }
+        kafka_alert = alert  # no fancy needed here
+        alert_list.append(kafka_alert)
+    return alert_list
+
+
+@pytest.fixture
+def cool_kafka_qm(
+    tlookup: TargetLookup,
+    mock_alert_list: list[dict],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    def mock_listen():
+        return mock_alert_list
+
+    qm = CoolKafkaQM({}, tlookup, tmp_path)
+    monkeypatch.setattr(qm, "listen_for_alerts", mock_listen)
     return qm
 
 
@@ -72,18 +171,18 @@ class Test__MissingABCMethodsFails:
     def test__no_name_fails(self):
         # Act
         with pytest.raises(TypeError):
-            qm = NoNameQM(target_lookup={})
+            qm = NoNameQM({}, TargetLookup(), None)
 
     def test__no_perform_fails(self):
         # Act
         with pytest.raises(TypeError):
-            qm = NoPerformTasksQM({})
+            qm = NoPerformTasksQM({}, TargetLookup(), None)
 
 
 class Test__InitQM:
     def test__init_qm(self, tmp_path: Path):
         # Act
-        qm = CoolQM({}, {}, parent_path=tmp_path)
+        qm = CoolQM({}, TargetLookup(), parent_path=tmp_path)
 
         # Assert
         assert isinstance(qm, BaseQueryManager)
@@ -93,28 +192,28 @@ class Test__ProcessPaths:
 
     def test__with_parent_path(self, cool_qm: BaseQueryManager, tmp_path: Path):
         # Act
-        cool_qm.process_paths(parent_path=tmp_path, directories=["lightcurves"])
+        cool_qm.process_paths(parent_path=tmp_path, directories=["some_data"])
 
         # Assert
-        assert set(cool_qm.paths_lookup.keys()) == set(["lightcurves"])
+        assert set(cool_qm.paths_lookup.keys()) == set(["some_data"])
 
-        exp_lc_path = tmp_path / "cool/lightcurves"  # NAME is prepended!
-        assert cool_qm.paths_lookup["lightcurves"] == exp_lc_path
-        assert cool_qm.paths_lookup["lightcurves"].exists()
-        assert hasattr(cool_qm, "lightcurves_path")
+        exp_lc_path = tmp_path / "cool/some_data"  # NAME is prepended!
+        assert cool_qm.paths_lookup["some_data"] == exp_lc_path
+        assert cool_qm.paths_lookup["some_data"].exists()
+        assert hasattr(cool_qm, "some_data_path")
 
     def test__with_data_path(self, cool_qm: BaseQueryManager, tmp_path: Path):
         # Act
-        cool_qm.process_paths(data_path=tmp_path, directories=["lightcurves"])
+        cool_qm.process_paths(data_path=tmp_path, directories=["some_data"])
 
         # Assert
-        assert cool_qm.paths_lookup["lightcurves"] == tmp_path / "lightcurves"
+        assert cool_qm.paths_lookup["some_data"] == tmp_path / "some_data"
 
     def test__data_or_parent_required(self, cool_qm: BaseQueryManager):
 
         # Act
         with pytest.raises(ValueError):
-            cool_qm.process_paths(directories=["lightcurves"])
+            cool_qm.process_paths(directories=["some_data"])
 
     def test__data_and_parent_ignores(self, cool_qm: BaseQueryManager, tmp_path: Path):
         # Act
@@ -129,105 +228,33 @@ class Test__ProcessPaths:
     def test__no_create(self, cool_qm: BaseQueryManager, tmp_path: Path):
         # Act
         cool_qm.process_paths(
-            parent_path=tmp_path, create_paths=False, directories=["lightcurves"]
+            parent_path=tmp_path, create_paths=False, directories=["some_data"]
         )
 
         # Assert
-        assert set(cool_qm.paths_lookup.keys()) == set(["lightcurves"])
+        assert set(cool_qm.paths_lookup.keys()) == set(["some_data"])
 
-        exp_lc_path = tmp_path / "cool/lightcurves"  # NAME is prepended!
-        assert cool_qm.paths_lookup["lightcurves"] == exp_lc_path
-        assert not cool_qm.paths_lookup["lightcurves"].exists()
-        assert hasattr(cool_qm, "lightcurves_path")
-
-
-class Test__LoadLCs:
-    def test__load_lcs(self, cool_qm: BaseQueryManager):
-        # Arrange
-        T00 = cool_qm.target_lookup["T00"]
-        assert set(T00.target_data.keys()) == set(["src01"])  # just a reminder...
-
-        # Act
-        loaded, skipped, missing = cool_qm.load_target_lightcurves()
-
-        # Assert
-        assert set(T00.target_data.keys()) == set(["src01", "cool"])
-        assert len(T00.target_data["cool"].lightcurve) == 14
-        assert not T00.updated
-
-        assert set(loaded) == set(["T00"])
-        assert set(skipped) == set()
-        assert set(missing) == set(["T01"])
-
-    def test__load_lcs_flag_new_targets(self, cool_qm: BaseQueryManager):
-        # Arrange
-        T00 = cool_qm.target_lookup["T00"]
-
-        # Act
-        loaded, skipped, missing = cool_qm.load_target_lightcurves(
-            only_flag_updated=False
-        )
-
-        # Assert
-        assert set(T00.target_data.keys()) == set(["src01", "cool"])
-        assert len(T00.target_data["cool"].lightcurve) == 14
-        assert T00.updated
-
-    def test__identical_lc_not_flagged(self, cool_qm: BaseQueryManager):
-        # Arrange
-        T00 = cool_qm.target_lookup["T00"]
-        cool_qm.load_target_lightcurves()
-
-        # Act
-        loaded, skipped, missing = cool_qm.load_target_lightcurves()
-
-        # Assert
-        assert set(loaded) == set()
-        assert set(skipped) == set(["T00"])  # didn't do anything to T00
-        assert set(missing) == set(["T01"])
-        assert not T00.updated
-
-    def test__load_named_targets_only(self, cool_qm: BaseQueryManager):
-        # Act
-        loaded, skipped, missing = cool_qm.load_target_lightcurves(id_list=["T00"])
-
-        assert set(loaded) == set(["T00"])
-        assert set(skipped) == set()
-        assert set(missing) == set()
-
-    def test__missing_target_warns(self, cool_qm: BaseQueryManager):
-        # Act
-        with pytest.warns(UnknownTargetWarning):
-            loaded, skipped, missing = cool_qm.load_target_lightcurves(id_list=["Txx"])
-
-        assert set(loaded) == set()
-        assert set(skipped) == set()
-        assert set(missing) == set(["Txx"])
-
-    def test__no_load_single_method(self, tlookup: TargetLookup):
-        # Arrange
-        qm = CoolQM({}, tlookup)
-
-        # Act
-        with pytest.raises(NotImplementedError):
-            qm.load_target_lightcurves()
+        exp_lc_path = tmp_path / "cool/some_data"  # NAME is prepended!
+        assert cool_qm.paths_lookup["some_data"] == exp_lc_path
+        assert not cool_qm.paths_lookup["some_data"].exists()
+        assert hasattr(cool_qm, "some_data_path")
 
 
 class Test__ClearStaleFiles:
 
     def test__stale_files(self, cool_qm: BaseQueryManager, tmp_path: Path):
         # Arrange
-        cool_qm.process_paths(parent_path=tmp_path, directories=["lightcurves"])
+        cool_qm.process_paths(parent_path=tmp_path, directories=["some_data"])
 
-        lc_dir = tmp_path / "cool/lightcurves"
-        lc_001 = lc_dir / "lc_001.csv"
-        lc_001.touch()
-        dir_A = lc_dir / "dir_A"
-        dir_A.mkdir(exist_ok=True)
-        lc_A01 = dir_A / "lc_A01.csv"
-        lc_A01.touch()
-        lc_A02 = dir_A / "lc_A02.csv"
-        lc_A02.touch()
+        data_dir = tmp_path / "cool/some_data"
+        data_001 = data_dir / "data_001.csv"
+        data_001.touch()
+        subdir_A = data_dir / "dir_A"
+        subdir_A.mkdir(exist_ok=True)
+        data_A01 = subdir_A / "data_A01.csv"
+        data_A01.touch()
+        data_A02 = subdir_A / "data_A02.csv"
+        data_A02.touch()
 
         t_future = Time.now() + 1.0 * u.day
 
@@ -235,25 +262,25 @@ class Test__ClearStaleFiles:
         cool_qm.clear_stale_files(t_ref=t_future, stale_age=0.5)
 
         # Assert
-        assert lc_dir.exists()
-        assert not lc_001.exists()
-        assert not dir_A.exists()
-        assert not lc_A01.exists()
-        assert not lc_A02.exists()
+        assert data_dir.exists()
+        assert not data_001.exists()
+        assert not subdir_A.exists()
+        assert not data_A01.exists()
+        assert not data_A02.exists()
 
-    def test__stale_files(self, cool_qm: BaseQueryManager, tmp_path: Path):
+    def test__keep_fresh_files(self, cool_qm: BaseQueryManager, tmp_path: Path):
         # Arrange
-        cool_qm.process_paths(parent_path=tmp_path, directories=["lightcurves"])
+        cool_qm.process_paths(parent_path=tmp_path, directories=["some_data"])
 
-        lc_dir = tmp_path / "cool/lightcurves"
-        lc_001 = lc_dir / "lc_001.csv"
-        lc_001.touch()
-        dir_A = lc_dir / "dir_A"
-        dir_A.mkdir(exist_ok=True)
-        lc_A01 = dir_A / "lc_A01.csv"
-        lc_A01.touch()
-        lc_A02 = dir_A / "lc_A02.csv"
-        lc_A02.touch()
+        data_dir = tmp_path / "cool/some_data"
+        data_001 = data_dir / "data_001.csv"
+        data_001.touch()
+        subdir_A = data_dir / "dir_A"
+        subdir_A.mkdir(exist_ok=True)
+        data_A01 = subdir_A / "data_A01.csv"
+        data_A01.touch()
+        data_A02 = subdir_A / "data_A02.csv"
+        data_A02.touch()
 
         t_future = Time.now() + 1.0 * u.day
 
@@ -261,8 +288,146 @@ class Test__ClearStaleFiles:
         cool_qm.clear_stale_files(t_ref=t_future, stale_age=1.5)
 
         # Assert
-        assert lc_dir.exists()
-        assert lc_001.exists()
-        assert dir_A.exists()
-        assert lc_A01.exists()
-        assert lc_A02.exists()
+        assert data_dir.exists()
+        assert data_001.exists()
+        assert subdir_A.exists()
+        assert data_A01.exists()
+        assert data_A02.exists()
+
+
+class Test__BadLightcurveQM:
+    def test__no_single_raises(self):
+        # Act
+        with pytest.raises(TypeError):
+            qm = BadLCQM(config={}, target_lookup={})
+
+
+class Test__IdResolvingOrder:
+    def test__take_preferred(
+        self, cool_lc_qm: LightcurveQueryManager, basic_target: Target
+    ):
+        # Arrange
+        assert cool_lc_qm.id_resolving_order == ("src01", "src02")  # reminder
+
+        # Act
+        relevant_name = cool_lc_qm.get_relevant_id_from_target(basic_target)
+
+        # Assert
+        assert relevant_name == "T00"
+
+    def test__take_next_best(
+        self, cool_lc_qm: LightcurveQueryManager, basic_target: Target
+    ):
+        # Arrange
+        assert cool_lc_qm.id_resolving_order == ("src01", "src02")  # reminder
+        basic_target.alt_ids.pop("src01")  # so that src02 is the only available...
+
+        # Act
+        relevant_name = cool_lc_qm.get_relevant_id_from_target(basic_target)
+
+        # Assert
+        assert relevant_name == "target_A"
+
+    def test__no_relevant_name_returns_none(
+        self, cool_lc_qm: LightcurveQueryManager, basic_target: Target
+    ):
+        # Arrange
+        assert cool_lc_qm.id_resolving_order == ("src01", "src02")  # reminder
+        basic_target.alt_ids = {}  # now neither src01 OR src02 exists!
+
+        # Act
+        relevant_name = cool_lc_qm.get_relevant_id_from_target(basic_target)
+
+        # Assert
+        assert relevant_name is None
+
+
+class Test__LoadLCs:
+    def test__load_lcs(self, cool_lc_qm: LightcurveQueryManager):
+        # Arrange
+        T00 = cool_lc_qm.target_lookup["T00"]
+        assert set(T00.target_data.keys()) == set(["src01"])  # just a reminder...
+
+        # Act
+        loaded, skipped, missing = cool_lc_qm.load_target_lightcurves()
+
+        # Assert
+        assert set(T00.target_data.keys()) == set(["src01", "cool_lc"])
+        assert len(T00.target_data["cool_lc"].lightcurve) == 14
+        assert not T00.updated
+
+        assert set(loaded) == set(["T00"])
+        assert set(skipped) == set()
+        assert set(missing) == set(["T01"])
+
+    def test__load_lcs_flag_new_targets(self, cool_lc_qm: LightcurveQueryManager):
+        # Arrange
+        T00 = cool_lc_qm.target_lookup["T00"]
+
+        # Act
+        loaded, skipped, missing = cool_lc_qm.load_target_lightcurves(
+            only_flag_updated=False
+        )
+
+        # Assert
+        assert set(T00.target_data.keys()) == set(["src01", "cool_lc"])
+        assert len(T00.target_data["cool_lc"].lightcurve) == 14
+        assert T00.updated
+
+    def test__identical_lc_not_flagged(self, cool_lc_qm: LightcurveQueryManager):
+        # Arrange
+        T00 = cool_lc_qm.target_lookup["T00"]
+        cool_lc_qm.load_target_lightcurves()
+
+        # Act
+        loaded, skipped, missing = cool_lc_qm.load_target_lightcurves()
+
+        # Assert
+        assert set(loaded) == set()
+        assert set(skipped) == set(["T00"])  # didn't do anything to T00
+        assert set(missing) == set(["T01"])
+        assert not T00.updated
+
+    def test__load_named_targets_only(self, cool_lc_qm: LightcurveQueryManager):
+        # Act
+        loaded, skipped, missing = cool_lc_qm.load_target_lightcurves(id_list=["T00"])
+
+        assert set(loaded) == set(["T00"])
+        assert set(skipped) == set()
+        assert set(missing) == set()
+
+    def test__missing_target_warns(self, cool_lc_qm: LightcurveQueryManager):
+        # Act
+        with pytest.warns(UnknownTargetWarning):
+            loaded, skipped, missing = cool_lc_qm.load_target_lightcurves(
+                id_list=["Txx"]
+            )
+
+        assert set(loaded) == set()
+        assert set(skipped) == set()
+        assert set(missing) == set(["Txx"])
+
+
+class Test__KafkaQMMethods:
+    def test__listen_for_alerts(self, cool_kafka_qm: KafkaQueryManager):
+        # Act
+        alerts = cool_kafka_qm.listen_for_alerts()  # boring test!
+
+        # Assert
+        assert len(alerts) == 5
+
+    def test__new_targets_for_alerts(
+        self, cool_kafka_qm: KafkaQueryManager, mock_alert_list: list[dict]
+    ):
+        # Arrange
+        tl = cool_kafka_qm.target_lookup
+        assert set(tl.keys()) == set(["T00", "T01"])
+
+        # Act
+        targets_added = cool_kafka_qm.add_targets_from_alerts(mock_alert_list)
+
+        # Assert
+        assert set(targets_added) == set("T101 T102 T103 T104 T105".split())
+
+        # also check that the new targets are in the tlookup...
+        assert set(tl.keys()) == set("T00 T01 T101 T102 T103 T104 T105".split())

--- a/test_aas2rto/unit/query_managers/test__primary_qm.py
+++ b/test_aas2rto/unit/query_managers/test__primary_qm.py
@@ -56,7 +56,8 @@ class Test__InitPrimaryQM:
         pqm = PrimaryQueryManager(global_qm_config, tlookup, path_mgr)
 
         # Assert
-        exp_qms = ["atlas", "fink_ztf", "fink_lsst", "tns"]
+        exp_qms = "atlas fink_lsst fink_ztf lasair_lsst lasair_ztf tns yse".split()
+
         assert set(pqm.query_managers.keys()) == set(exp_qms)
 
         untested_qms = set(EXPECTED_QUERY_MANAGERS.keys()) - set(

--- a/test_aas2rto/unit/query_managers/test__primary_qm.py
+++ b/test_aas2rto/unit/query_managers/test__primary_qm.py
@@ -56,7 +56,7 @@ class Test__InitPrimaryQM:
         pqm = PrimaryQueryManager(global_qm_config, tlookup, path_mgr)
 
         # Assert
-        exp_qms = "atlas fink_lsst fink_ztf lasair_lsst lasair_ztf tns yse".split()
+        exp_qms = "atlas fink_lsst fink_ztf tns yse".split()  # lasair_lsst lasair_ztf
 
         assert set(pqm.query_managers.keys()) == set(exp_qms)
 

--- a/test_aas2rto/unit/scoring/test__sn_peak_score.py
+++ b/test_aas2rto/unit/scoring/test__sn_peak_score.py
@@ -31,24 +31,6 @@ def t_score():
     return Time(60010.0, format="mjd")
 
 
-# @pytest.fixture
-# def lc_ztf(lc_pandas: pd.DataFrame):
-#     col_mapping = {
-#         "obsid": "candid",
-#         "mag": "magpsf",
-#         "magerr": "sigmapsf",
-#         "band": "fid",
-#     }
-#     lc_pandas.rename(col_mapping, inplace=True, axis=1)
-#     lc_pandas.loc[:, "blah"] = 100.0
-#     return lc_pandas
-
-
-# @pytest.fixture
-# def ztf_td(lc_ztf: pd.DataFrame):
-#     return TargetData(lightcurve=lc_ztf)
-
-
 @pytest.fixture
 def salt_model():
     model = sncosmo.Model(source="salt3")


### PR DESCRIPTION
- Refactored BaseQM into BaseQM, LightcurveQM and KafkaQM
    - move duplicated code to base class
- Finish FinkLSSTQM, tests for FinkLSSTQM
- Add LSST formatter to lightcurve compiler
Minor:
    - Rename poorly named 'FinkQuery' to 'FinkPortalClient'
    - fix bug where old ordered plots were not being removed
    - reduce telegram error for failed send
    - fix bug in redirect pages for static_page_manager
