### PR TITLE
Fix/fink portal lsst

### DIFF
--- a/aas2rto/path_manager.py
+++ b/aas2rto/path_manager.py
@@ -42,18 +42,18 @@ class PathManager:
         base_path = self.config["base_path"]
         self.base_path = Path(base_path)
 
-        project_path = self.config["project_path"] or "default"
-        project_name = self.config["project_name"] or "default"
+        projects_base = self.base_path / "projects"
+        projects_base.mkdir(exist_ok=True, parents=True)
+
+        project_path = self.config["project_path"]
+        project_name = self.config["project_name"]
         if project_path == "default":
             if project_name == "default":
-                msg = (
+                msg = ()
+                logger.info(
                     "You can set the name of the project_path by providing "
-                    "'project_name' in 'paths:'. set to 'default'"
+                    "'project_name' in 'paths:'. Set to 'default'"
                 )
-                logger.info(msg)
-                project_name = "default"
-            projects_base = self.base_path / "projects"
-            projects_base.mkdir(exist_ok=True, parents=True)
             project_path = projects_base / project_name
         self.project_path = Path(project_path)
 

--- a/aas2rto/plotting/default_plotter.py
+++ b/aas2rto/plotting/default_plotter.py
@@ -101,11 +101,18 @@ class DefaultLightcurvePlotter:
             "no_band": "k",
         }
 
-        ztf_shapes = {x: "o" for x in "ztfg ztfr ztfi".split()}
-        atlas_shapes = {x: "o" for x in "atlasc atlaso".split()}
-        yse_shapes = {f"ps1::{x}": "s" for x in "g r i z y w".split()}
+        ztf_shapes = {x: "o" for x in self.ztf_colors.keys()}
+        atlas_shapes = {x: "o" for x in self.atlas_colors.keys()}
+        lsst_shapes = {x: "s" for x in self.lsst_colors.keys()}
+        yse_shapes = {x: "^" for x in self.yse_colors.keys()}
         swift_shapes = {f"uvot::{x}": "v" for x in "u b v uvw1 uvw2 uvm1 uvm2".split()}
-        self.plot_shapes = {**ztf_shapes, **atlas_shapes, **yse_shapes, **swift_shapes}
+        self.plot_shapes = {
+            **ztf_shapes,
+            **atlas_shapes,
+            **lsst_shapes,
+            **yse_shapes,
+            **swift_shapes,
+        }
 
         self.valid_kwargs = dict(ls="none")  # , marker="o")
         self.ulimit_kwargs = dict(ls="none")  # , marker="v", mfc="none")
@@ -222,7 +229,7 @@ class DefaultLightcurvePlotter:
             if len(detections) > 0:
                 xdat = detections["mjd"] - self.t_ref.mjd
                 ydat = detections[self.mag_col]
-                yerr = detections[self.magerr_col]
+                yerr = np.maximum(detections[self.magerr_col], 0.0)
                 self.ax.errorbar(
                     xdat, ydat, yerr=yerr, **det_kwargs, **self.valid_kwargs
                 )
@@ -288,7 +295,11 @@ class DefaultLightcurvePlotter:
         self.fig.subplots_adjust(top=0.85)
 
         names = list(set(target.alt_ids.values()))
-        title = " -- ".join(sorted(names))
+
+        if names:
+            title = " -- ".join(sorted(names))
+        else:
+            title = str(target.target_id)
 
         transform_kwargs = dict(ha="center", va="top", transform=self.fig.transFigure)
         self.ax.text(0.5, 0.98, title, fontsize=14, **transform_kwargs)
@@ -305,7 +316,7 @@ class DefaultLightcurvePlotter:
 
         self.ax.text(0.5, 0.93, subtitle, fontsize=11, **transform_kwargs)
 
-        self.peakmag_vals.append(17.0)
+        self.peakmag_vals.append(21.0)
         y_bright = np.nanmin(self.peakmag_vals) - 0.2
         self.faintmag_vals.append(22.0)
         y_faint = np.nanmax(self.faintmag_vals) + 0.2

--- a/aas2rto/query_managers/fink/fink_base.py
+++ b/aas2rto/query_managers/fink/fink_base.py
@@ -504,7 +504,7 @@ class FinkBaseQueryManager(LightcurveQueryManager, KafkaQueryManager, abc.ABC):
 
             t1 = time.perf_counter()
             try:
-                result = self.portal_client.query_lightcurve(
+                result: pd.DataFrame = self.portal_client.query_lightcurve(
                     return_type="pandas", **payload
                 )
                 chunk_results.append(result)
@@ -525,10 +525,12 @@ class FinkBaseQueryManager(LightcurveQueryManager, KafkaQueryManager, abc.ABC):
                 logger.warning(msg)
                 result[self.target_id_key] = "0"  # Still need to to split on target_id
 
+            result[self.target_id_key] = result[self.target_id_key].astype(str)
+
             for fink_id in fink_id_chunk:
 
-                id_mask = result[self.target_id_key].str == fink_id
-                unprocessed_lc = result[]
+                id_mask = result[self.target_id_key] == fink_id
+                unprocessed_lc = result[id_mask]
                 processed_lc = self.process_fink_lightcurve(unprocessed_lc)
 
                 if processed_lc.empty:

--- a/aas2rto/query_managers/fink/fink_base.py
+++ b/aas2rto/query_managers/fink/fink_base.py
@@ -51,18 +51,6 @@ logger = getLogger(__name__.split(".")[-1])
 
 FinkAlert = NewType("FinkAlert", tuple[str, dict, str])
 
-EXTRA_FINK_ALERT_KEYS = (
-    # "timestamp", # doesn't exist anymore?!
-    "cdsxmatch",
-    "rf_snia_vs_nonia",
-    "snn_snia_vs_nonia",
-    "snn_sn_vs_all",
-    "mulens",
-    "roid",
-    "nalerthist",
-    "rf_kn_vs_nonkn",
-)
-
 
 def updates_from_classifier_queries(
     existing_results: pd.DataFrame,
@@ -182,7 +170,13 @@ class FinkBaseQueryManager(LightcurveQueryManager, KafkaQueryManager, abc.ABC):
     ##===== Generic methods start here =====##
 
     DEFAULT_TASKS = ("alerts", "queries", "lightcurves", "cutouts", "stale_files")
-    REQUIRED_KAFKA_PARAMS = ("username", "group.id", "bootstrap.servers", "topics")
+    REQUIRED_KAFKA_PARAMS = (
+        "username",
+        "group.id",
+        "bootstrap.servers",
+        "topics",
+        "survey",
+    )
     REQUIRED_DIRECTORIES = ("alerts", "cutouts", "lightcurves", "query_results")
 
     default_config = {
@@ -398,7 +392,7 @@ class FinkBaseQueryManager(LightcurveQueryManager, KafkaQueryManager, abc.ABC):
 
             ##== Perform the query
             t_start = t_ref - lookback * u.day
-            new_results = self.portal_client.latests_query_and_collate(
+            new_results = self.portal_client.query_classifiers(
                 t_start=t_start, class_=fink_class, return_type="pandas"
             )  # trailing "_"  from 'class_' is stripped...
             if len(new_results) == 0:
@@ -498,7 +492,7 @@ class FinkBaseQueryManager(LightcurveQueryManager, KafkaQueryManager, abc.ABC):
                 logger.warning("Stop LC queries for now")
                 break
 
-            chunk_str = ",".join(fink_id_chunk)
+            chunk_str = ",".join([str(fink_id) for fink_id in fink_id_chunk])
             logger.info(f"start LC query chunk {ii+1} ({len(fink_id_chunk)} LCs)")
             payload = {
                 self.target_id_key: chunk_str,
@@ -510,7 +504,9 @@ class FinkBaseQueryManager(LightcurveQueryManager, KafkaQueryManager, abc.ABC):
 
             t1 = time.perf_counter()
             try:
-                result = self.portal_client.objects(return_type="pandas", **payload)
+                result = self.portal_client.query_lightcurve(
+                    return_type="pandas", **payload
+                )
                 chunk_results.append(result)
             except Exception as e:
                 msg = f"LC query chunk {ii+1} failed:\n    {type(e).__name__}: {e}"
@@ -530,7 +526,9 @@ class FinkBaseQueryManager(LightcurveQueryManager, KafkaQueryManager, abc.ABC):
                 result[self.target_id_key] = "0"  # Still need to to split on target_id
 
             for fink_id in fink_id_chunk:
-                unprocessed_lc = result[result[self.target_id_key] == fink_id]
+
+                id_mask = result[self.target_id_key].str == fink_id
+                unprocessed_lc = result[]
                 processed_lc = self.process_fink_lightcurve(unprocessed_lc)
 
                 if processed_lc.empty:

--- a/aas2rto/query_managers/fink/fink_lsst.py
+++ b/aas2rto/query_managers/fink/fink_lsst.py
@@ -38,6 +38,8 @@ class FinkLSSTQueryManager(FinkBaseQueryManager):
     portal_client_class = FinkLSSTPortalClient
     # DO NOT init portal_client here: happens in QM init, in case credentials needed...
 
+    config_extras = {"reliability_cutoff": 0.5}
+
     def process_single_alert(self, alert_data: FinkAlert, t_ref: Time = None):
         topic, data, key = alert_data
         fink_id = data["diaObject"][self.target_id_key]
@@ -89,7 +91,7 @@ def process_fink_lsst_alert(
     object_data: dict = data["diaObject"]
     alert: dict = data["diaSource"]
 
-    fink_id: int = object_data[LSST_TARGET_ID_KEY]
+    fink_id: int = str(object_data[LSST_TARGET_ID_KEY])
     alert_id: int = alert[LSST_ALERT_ID_KEY]
 
     # Now modify the alert dict - diaSourceId (alert_id) is already included
@@ -129,7 +131,7 @@ def process_fink_lsst_alert(
 def target_from_fink_lsst_alert(processed_alert: dict, t_ref: Time = None):
     t_ref = t_ref or Time.now()
 
-    target_id = processed_alert[LSST_TARGET_ID_KEY]
+    target_id = str(processed_alert[LSST_TARGET_ID_KEY])
     ra = processed_alert.get("ra", None)
     dec = processed_alert.get("dec", None)
     if (ra is None) or (dec is None):
@@ -144,7 +146,7 @@ def apply_fink_lsst_updates_to_target(
 ) -> NoReturn:
     t_ref = t_ref or Time.now()
 
-    fink_id = processed_alert[LSST_TARGET_ID_KEY]
+    fink_id = str(processed_alert[LSST_TARGET_ID_KEY])
     topic = processed_alert["topic"]
     alert_id = processed_alert[LSST_ALERT_ID_KEY]
     flux = processed_alert["psfFlux"]  # flux is in nJy
@@ -171,3 +173,5 @@ def process_fink_lsst_lightcurve(unprocessed_lc: pd.DataFrame):
 
     if LSST_ALERT_ID_KEY not in lightcurve.columns:
         lightcurve.loc[:, LSST_ALERT_ID_KEY] = -1
+
+    return lightcurve

--- a/aas2rto/query_managers/fink/fink_lsst.py
+++ b/aas2rto/query_managers/fink/fink_lsst.py
@@ -17,7 +17,6 @@ from aas2rto.query_managers.fink.fink_base import (
     FinkBaseQueryManager,
     FinkAlert,
     readstamp,
-    EXTRA_FINK_ALERT_KEYS,
 )
 from aas2rto.query_managers.fink.fink_portal_client import FinkLSSTPortalClient
 from aas2rto.target import Target
@@ -27,6 +26,8 @@ logger = getLogger(__name__.split(".")[-1])
 
 LSST_TARGET_ID_KEY = "diaObjectId"
 LSST_ALERT_ID_KEY = "diaSourceId"
+
+EXTRA_FINK_LSST_ALERT_KEYS = ()
 
 
 class FinkLSSTQueryManager(FinkBaseQueryManager):
@@ -98,9 +99,9 @@ def process_fink_lsst_alert(
     alert["tag"] = "valid"  # if it's arrived as an alert, it must be valid...
     alert["nDiaSources"] = object_data["nDiaSources"]
 
-    extra_data = {k: data[k] for k in EXTRA_FINK_ALERT_KEYS if k in data}
+    extra_data = {k: data[k] for k in EXTRA_FINK_LSST_ALERT_KEYS if k in data}
     utils.check_missing_config_keys(
-        data, EXTRA_FINK_ALERT_KEYS, name=f"fink_lsst.{topic}.{fink_id}.{alert_id}"
+        data, EXTRA_FINK_LSST_ALERT_KEYS, name=f"fink_lsst.{topic}.{fink_id}.{alert_id}"
     )
     alert.update(extra_data)
 

--- a/aas2rto/query_managers/fink/fink_portal_client.py
+++ b/aas2rto/query_managers/fink/fink_portal_client.py
@@ -5,6 +5,7 @@ import json
 import requests
 import time
 from logging import getLogger
+from typing import Callable
 
 import numpy as np
 
@@ -17,8 +18,27 @@ from astropy.time import Time
 logger = getLogger(__name__.split(".")[-1])
 
 
-class FinkPortalClientError(Exception):
+class FinkPortalClientError(Exception):  # Try to keep this standalone...
     pass
+
+
+class FinkBadEndpointError(Exception):
+    pass
+
+
+class FinkDisallowedMethodError(Exception):
+    pass
+
+
+class FinkMissingRequiredParametersError(Exception):
+    pass
+
+
+RESPONSE_PROCESSORS = {
+    "pandas": pd.DataFrame,
+    "astropy": lambda data: Table(rows=data),
+    "records": lambda data: data,
+}
 
 
 class FinkBasePortalClient(abc.ABC):
@@ -28,17 +48,31 @@ class FinkBasePortalClient(abc.ABC):
     @property
     @abc.abstractmethod
     def api_url(self) -> str:
-        pass
+        """The url for the fink endpoint eg. api.{survey}.fink-portal.org"""
 
     @property
     @abc.abstractmethod
     def imtypes(self) -> tuple[str]:
-        pass
+        """"""
 
     @property
     @abc.abstractmethod
-    def id_key(self) -> str:
-        pass
+    def target_id_key(self) -> str:
+        """"""
+
+    @property
+    @abc.abstractmethod
+    def alert_id_key(self) -> str:
+        """"""
+
+    @abc.abstractmethod
+    def query_lightcurve(self, *args, **payload):
+        """Define which endpoint should be used for querying a lightcurve.
+        eg. they are different for LSST and ZTF!"""
+
+    @abc.abstractmethod
+    def query_classifiers(self, *args, **payload):
+        """"""
 
     def __init__(self):
         pass  # In case of credentials required, implement here
@@ -51,23 +85,6 @@ class FinkBasePortalClient(abc.ABC):
             data[new_key] = data.pop(old_key)
         # NO RETURN - dictionary is modified "in place"...
 
-    def process_data(self, data, fix_keys=True, return_type="records", df_kwargs=None):
-        if fix_keys:
-            for row in data:
-                self.fix_dict_keys_inplace(row)
-        if return_type == "records":
-            return data
-        elif return_type == "pandas":
-            return pd.DataFrame(data)
-        elif return_type == "astropy":
-            return Table(rows=data)
-        else:
-            return_type_err_msg = (
-                f"Unknown return_type='\033[33;1m{return_type}\033[0m'. Choose from:\n    "
-                "'pandas', 'astropy', 'records'"
-            )
-            raise ValueError(return_type_err_msg)
-
     @staticmethod
     def process_kwargs(**kwargs):
         """Remove trailing underscores from eg. 'class_'
@@ -77,69 +94,210 @@ class FinkBasePortalClient(abc.ABC):
         """
         return {k.rstrip("_"): v for k, v in kwargs.items()}
 
-    def process_response(
-        self, response: requests.Response, fix_keys=True, return_type=None
-    ):
-        if response.status_code in [404, 500, 504]:
-            logger.error("\033[31;1mFinkQuery: error rasied\033[0m")
-            if response.elapsed.total_seconds() > self.TIMEOUT_LIKELY:
-                logger.error("likely a timeout error")
-            if isinstance(response.content, bytes):
-                raise FinkPortalClientError(response.content.decode())
-            else:
-                raise FinkPortalClientError(response.content)
-        data = json.loads(response.content)
-        return self.process_data(data, fix_keys=fix_keys, return_type=return_type)
+    @staticmethod
+    def disallow_http_method(method, disallowed, endpoint: str = "<unknown>"):
+        if method == disallowed:
+            msg = f"method '{method}' disallowed for endpoint '{endpoint}'"
+            raise FinkDisallowedMethodError(msg)
+        return
 
-    def do_post(
-        self, service: str, process=True, fix_keys=True, return_type=None, **kwargs
+    @staticmethod
+    def raise_client_error(response: requests.Response, endpoint="<unknown>"):
+        status = response.status_code
+        reason = response.reason
+        msg = f"query for '{endpoint}' returned status {status} ({reason})"
+        logger.error(msg)
+        if isinstance(response.content, bytes):
+            raise FinkPortalClientError(response.content.decode())
+        else:
+            raise FinkPortalClientError(response.content)
+
+    def do_request(
+        self,
+        endpoint: str,
+        process=True,
+        fix_keys=True,
+        return_type=None,
+        method: str = "post",
+        **payload,
     ):
-        kwargs = self.process_kwargs(**kwargs)
-        response: requests.Response = requests.post(
-            f"{self.api_url}/{service}", json=kwargs
-        )
+        payload = self.process_kwargs(**payload)
+        if method == "post":
+            response: requests.Response = requests.post(
+                f"{self.api_url}/{endpoint}", json=payload
+            )
+        elif method == "get":
+            response: requests.Response = requests.get(
+                f"{self.api_url}/{endpoint}", params=payload
+            )
+        else:
+            msg = f"Unknown method '{method}'. Choose 'post' or 'get'"
+            raise ValueError(msg)
         if response.status_code != 200:
-            time.sleep(0.1)
-            msg = f"query for '{service}' returned status {response.status_code}"
-            logger.warning(msg)
+            self.raise_client_error(response, endpoint=endpoint)
+
         if process:
             return self.process_response(
                 response, fix_keys=fix_keys, return_type=return_type
             )
         return response
 
-    def do_get(self, service: str, process=True, **kwargs):
-        response: requests.Response = requests.get(
-            f"{self.api_url}/{service}", json=kwargs
+    def process_response(
+        self,
+        response: requests.Response,
+        fix_keys: bool = True,
+        return_type: bool = None,
+    ):
+        data = json.loads(response.content)
+        return self.process_data(data, fix_keys=fix_keys, return_type=return_type)
+
+    def process_data(self, data, fix_keys=True, return_type="records", df_kwargs=None):
+        if fix_keys:
+            for row in data:
+                self.fix_dict_keys_inplace(row)
+        processor = RESPONSE_PROCESSORS.get(return_type)
+        if processor is None:
+            processors_str = ", ".join(f"'{x}'" for x in RESPONSE_PROCESSORS.keys())
+            return_type_err_msg = (
+                f"Unknown return_type='\033[33;1m{return_type}\033[0m'. Choose from:\n    "
+                f"{processors_str}"
+            )
+            raise ValueError(return_type_err_msg)
+        return processor(data)
+
+    ##===== Methods which look common among surveys =====##
+    # ...and do the same thing in each survey.
+
+    def cutouts(self, method: str = "post", **payload):
+        cutouts_kind = payload.get("kind", None)
+        if (cutouts_kind is not None) and (cutouts_kind not in self.imtypes):
+            raise ValueError(f"cutouts kind must be in 'imtypes'")
+
+        client_kwargs = dict(method=method)
+        return self.do_request("cutouts", **client_kwargs, **payload)
+
+    def conesearch(
+        self, method="post", process=True, fix_keys=True, return_type=None, **payload
+    ):
+        client_kwargs = dict(
+            method=method, process=process, fix_keys=fix_keys, return_type=return_type
         )
-        if response.status_code != 200:
-            if isinstance(response.content, bytes):
-                raise FinkPortalClientError(response.content.decode())
-            else:
-                raise FinkPortalClientError(response.content)
-        if process:
-            try:
-                return json.loads(response.content)
-            except Exception as e:
-                return response.content.decode()
-        return response
+        return self.do_request("conesearch", **client_kwargs, **payload)
 
-    def objects(self, fix_keys=True, return_type=None, **kwargs):
-        return self.do_post(
-            "objects", fix_keys=fix_keys, return_type=return_type, **kwargs
+    def sso(
+        self, method="post", process=True, fix_keys=True, return_type=None, **payload
+    ):
+        client_kwargs = dict(
+            method=method, process=process, fix_keys=fix_keys, return_type=return_type
+        )
+        return self.do_request("sso", **client_kwargs, **payload)
+
+    def schema(self, method="get", **payload):
+        client_kwargs = dict(method=method, fix_keys=False, return_type="records")
+        return self.do_request("schema", **client_kwargs, **payload)
+
+    def skymap(
+        self, method="post", process=True, fix_keys=True, return_type=None, **payload
+    ):
+        client_kwargs = dict(
+            method=method, process=process, fix_keys=fix_keys, return_type=return_type
+        )
+        return self.do_request("skymap", **client_kwargs, **payload)
+
+    def statistics(self, fix_keys=True, return_type=None, **payload):
+        return self.do_request(
+            "statistics", fix_keys=fix_keys, return_type=return_type, **payload
         )
 
-    def cutouts(self, **kwargs):
-        if kwargs.get("kind", None) not in self.imtypes:
-            raise ValueError(f"provide `kind` as one of {self.imtypes}")
-        return self.do_post("cutouts", fix_keys=False, **kwargs)
-
-    def latests(self, fix_keys=True, return_type=None, **kwargs):
-        return self.do_post(
-            "latests", fix_keys=fix_keys, return_type=return_type, **kwargs
+    def resolver(
+        self, method="post", process=True, fix_keys=True, return_type=None, **payload
+    ):
+        client_kwargs = dict(
+            method=method, process=process, fix_keys=fix_keys, return_type=return_type
         )
+        return self.do_request("resolver", **client_kwargs, **payload)
 
-    def latests_query_and_collate(
+
+class FinkZTFPortalClient(FinkBasePortalClient):
+    api_url = "https://api.ztf.fink-portal.org/api/v1"
+    target_id_key = "objectId"
+    alert_id_key = "candid"
+    imtypes = ("Difference", "Science", "Template")
+
+    def anomaly(
+        self, method="post", process=True, fix_keys=True, return_type=None, **payload
+    ):
+        client_kwargs = dict(
+            method=method, process=process, fix_keys=fix_keys, return_type=return_type
+        )
+        return self.do_request("anomaly", **client_kwargs, **payload)
+
+    def classes(
+        self, method="get", process=True, fix_keys=True, return_type=None, **payload
+    ):
+        self.disallow_http_method(method, disallowed="post", endpoint="classes")
+        client_kwargs = dict(
+            method="get", process=process, fix_keys=fix_keys, return_type=return_type
+        )
+        return self.do_request("classes", **client_kwargs, **payload)
+
+    def latests(
+        self, method="post", process=True, fix_keys=True, return_type=None, **payload
+    ):
+        client_kwargs = dict(
+            method=method, process=process, fix_keys=fix_keys, return_type=return_type
+        )
+        return self.do_request("latests", **client_kwargs, **payload)
+
+    def objects(
+        self, method="post", process=True, fix_keys=True, return_type=None, **payload
+    ):
+        # NOT a base class method, as it has different behaviour in each survey.
+        client_kwargs = dict(
+            method=method, process=process, fix_keys=fix_keys, return_type=return_type
+        )
+        return self.do_request("objects", **client_kwargs, **payload)
+
+    def schema(self, method="get", **payload):
+        """get method disallowed for ZTF schema endpoint"""
+        self.disallow_http_method(method, disallowed="post", endpoint="schema")
+        return super().schema(method=method, **payload)
+
+    def ssobulk(
+        self, method="post", process=True, fix_keys=True, return_type=None, **payload
+    ):
+        client_kwargs = dict(
+            method=method, process=process, fix_keys=fix_keys, return_type=return_type
+        )
+        return self.do_request("ssobulk", **client_kwargs, **payload)
+
+    def ssocand(
+        self, method="post", process=True, fix_keys=True, return_type=None, **payload
+    ):
+        client_kwargs = dict(
+            method=method, process=process, fix_keys=fix_keys, return_type=return_type
+        )
+        return self.do_request("ssocand", **client_kwargs, **payload)
+
+    def ssoft(
+        self, method="post", process=True, fix_keys=True, return_type=None, **payload
+    ):
+        client_kwargs = dict(
+            method=method, process=process, fix_keys=fix_keys, return_type=return_type
+        )
+        return self.do_request("ssoft", **client_kwargs, **payload)
+
+    def tracklet(
+        self, method="post", process=True, fix_keys=True, return_type=None, **payload
+    ):
+        client_kwargs = dict(
+            method=method, process=process, fix_keys=fix_keys, return_type=return_type
+        )
+        return self.do_request("tracklet", **client_kwargs, **payload)
+
+    ##===== Extra methods =====##
+
+    def query_classifiers(
         self,
         t_start: Time,
         t_stop: Time = None,
@@ -147,7 +305,7 @@ class FinkBasePortalClient(abc.ABC):
         return_type="pandas",
         fix_keys=True,
         n=1000,
-        **kwargs,
+        **payload,
     ):
         t_stop = t_stop or Time.now()
         step_day = step.to(u.day).value
@@ -156,15 +314,21 @@ class FinkBasePortalClient(abc.ABC):
         )
 
         results = []
-        kwargs["n"] = n
+        payload["n"] = n
         for t1, t2 in zip(t_grid[:-1], t_grid[1:]):
-            payload = copy.deepcopy(kwargs)
+            payload = copy.deepcopy(payload)
             t1_str = t1.strftime("%Y-%m-%d %H:%M")
             t2_str = t2.strftime("%Y-%m-%d %H:%M")
             payload["startdate"] = t1.iso
             payload["stopdate"] = t2.iso
             logger.info(f"start query {t1_str} - {t2_str}")
-            result = self.latests(fix_keys=fix_keys, return_type=return_type, **payload)
+            try:
+                result = self.latests(
+                    fix_keys=fix_keys, return_type=return_type, **payload
+                )
+            except FinkBadEndpointError as e:
+                break
+
             if len(result) == n:
                 msg = f"{t1_str} - {t2_str} returned {n} rows. choose shorter timestep!"
                 logger.warning(msg)
@@ -175,79 +339,102 @@ class FinkBasePortalClient(abc.ABC):
         elif return_type == "pandas":
             if len(results) > 0:
                 return pd.concat(results)
-            return pd.DataFrame(columns=[self.id_key])
+            return pd.DataFrame(columns=[self.target_id_key])
         elif return_type == "astropy":
             if len(results) > 0:
                 return vstack(results)
-            return Table(names=[self.id_key])
+            return Table(names=[self.target_id_key])
         else:
             msg = f"Unknown return_type='{return_type}': Use None, 'pandas', 'astropy'"
             raise ValueError(msg)
 
-    def classes(self, fix_keys=True, process=True, return_type=None, **kwargs):
-        return self.do_get("classes", process=process, **kwargs)
-
-    def explorer(self, fix_keys=True, return_type=None, **kwargs):
-        return self.do_post(
-            "explorer", fix_keys=fix_keys, return_type=return_type, **kwargs
+    def query_lightcurve(
+        self, method="post", process=True, fix_keys=True, return_type=None, **payload
+    ):
+        """ZTF lightcurves are queried with the OBJECTS endpoint"""
+        client_kwargs = dict(
+            method=method, process=process, fix_keys=fix_keys, return_type=return_type
         )
-
-    def conesearch(self, fix_keys=True, return_type=None, **kwargs):
-        return self.do_post(
-            "conesearch", fix_keys=fix_keys, return_type=return_type, **kwargs
-        )
-
-    def sso(self, fix_keys=True, return_type=None, **kwargs):
-        return self.do_post("sso", fix_keys=fix_keys, return_type=return_type, **kwargs)
-
-    def ssocand(self, fix_keys=True, return_type=None, **kwargs):
-        return self.do_post(
-            "ssocand", fix_keys=fix_keys, return_type=return_type, **kwargs
-        )
-
-    def resolver(self, fix_keys=True, return_type=None, **kwargs):
-        return self.do_post(
-            "resolver", fix_keys=fix_keys, return_type=return_type, **kwargs
-        )
-
-    def tracklet(self, fix_keys=True, return_type=None, **kwargs):
-        return self.do_post(
-            "tracklet", fix_keys=fix_keys, return_type=return_type, **kwargs
-        )
-
-    def schema(self, fix_keys=True, return_type=None, **kwargs):
-        return self.do_get(
-            "schema", fix_keys=fix_keys, return_type=return_type, **kwargs
-        )
-
-    def skymap(self, fix_keys=True, return_type=None, **kwargs):
-        return self.do_post(
-            "skymap", fix_keys=fix_keys, return_type=return_type, **kwargs
-        )
-
-    def statistics(self, fix_keys=True, return_type=None, **kwargs):
-        return self.do_post(
-            "statistics", fix_keys=fix_keys, return_type=return_type, **kwargs
-        )
-
-    def anomaly(self, fix_keys=True, return_type=None, **kwargs):
-        return self.do_post(
-            "anomaly", fix_keys=fix_keys, return_type=return_type, **kwargs
-        )
-
-    def ssoft(self, fix_keys=True, return_type=None, **kwargs):
-        return self.do_post(
-            "ssoft", fix_keys=fix_keys, return_type=return_type, **kwargs
-        )
-
-
-class FinkZTFPortalClient(FinkBasePortalClient):
-    api_url = "https://api.ztf.fink-portal.org/api/v1"
-    id_key = "objectId"
-    imtypes = ("Difference", "Science", "Template")
+        return self.objects(**client_kwargs, **payload)
 
 
 class FinkLSSTPortalClient(FinkBasePortalClient):
     api_url = "https://api.lsst.fink-portal.org/api/v1"
-    id_key = "diaObjectId"
+    target_id_key = "diaObjectId"
+    alert_id_key = "diaSourceId"
     imtypes = ("Difference", "Science", "Template")
+
+    def blocks(self, process=True, fix_keys=True, return_type=None, **payload):
+        """No method keyword here - only http 'get' method is allowed"""
+        client_kwargs = dict(
+            method="get", process=process, fix_keys=fix_keys, return_type=return_type
+        )
+        return self.do_request("blocks", **client_kwargs, **payload)
+
+    def fp(
+        self, method="post", process=True, fix_keys=True, return_type=None, **payload
+    ):
+        client_kwargs = dict(
+            method=method, process=process, fix_keys=fix_keys, return_type=return_type
+        )
+        return self.do_request("fp", **client_kwargs, **payload)
+
+    def objects(
+        self, method="post", process=True, fix_keys=True, return_type=None, **payload
+    ):
+        client_kwargs = dict(
+            method=method, process=process, fix_keys=fix_keys, return_type=return_type
+        )
+        return self.do_request("objects", **client_kwargs, **payload)
+
+    def sources(
+        self, method="post", process=True, fix_keys=True, return_type=None, **payload
+    ):
+        client_kwargs = dict(
+            method=method, process=process, fix_keys=fix_keys, return_type=return_type
+        )
+        return self.do_request("sources", **client_kwargs, **payload)
+
+    def tags(
+        self, method="post", process=True, fix_keys=True, return_type=None, **payload
+    ):
+        client_kwargs = dict(
+            method=method, process=process, fix_keys=fix_keys, return_type=return_type
+        )
+        return self.do_request("tags", **client_kwargs, **payload)
+
+    ##===== Extra methods =====##
+
+    def query_lightcurve(
+        self, method="post", process=True, fix_keys=True, return_type=None, **payload
+    ):
+        """LSST lightcurves are queried with the 'SOURCES' endpoint"""
+        client_kwargs = dict(
+            method=method, process=process, fix_keys=fix_keys, return_type=return_type
+        )
+        return self.sources(**client_kwargs, **payload)
+
+    def query_classifiers(
+        self, method="post", process=True, fix_keys=True, return_type=None, **payload
+    ):
+        client_kwargs = dict(
+            method=method, process=process, fix_keys=fix_keys, return_type=return_type
+        )
+        raise NotImplementedError("No query classifiers and collate for LSST")
+
+
+### Fancy decorator solution does not work for disallowing http methods because
+### decorator does not know about default arguments. Would need to use inspect,
+### which seems sketchy...
+#
+# def disallow_http_method(disallowed_method: str):
+#     def disallow_decorator(func):
+#         def check_method(endpoint, *args, method: str = None, **payload):
+#             if method == disallowed_method:
+#                 msg = f"method '{method}' disallowed for endpoint '{endpoint}'"
+#                 raise FinkDisallowedMethodError(msg)
+#             return func(endpoint, *args, method=method, **payload)
+
+#         return check_method
+
+#     return disallow_decorator

--- a/aas2rto/query_managers/fink/fink_portal_client.py
+++ b/aas2rto/query_managers/fink/fink_portal_client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import abc
 import copy
 import itertools
@@ -66,7 +68,7 @@ class FinkBasePortalClient(abc.ABC):
         """"""
 
     @abc.abstractmethod
-    def query_lightcurve(self, *args, **payload):
+    def query_lightcurve(self, *args, **payload) -> pd.DataFrame | Table | list[dict]:
         """Define which endpoint should be used for querying a lightcurve.
         eg. they are different for LSST and ZTF!"""
 

--- a/aas2rto/query_managers/fink/fink_ztf.py
+++ b/aas2rto/query_managers/fink/fink_ztf.py
@@ -23,7 +23,6 @@ from aas2rto.query_managers.fink.fink_base import (
     FinkBaseQueryManager,
     FinkAlert,
     readstamp,
-    EXTRA_FINK_ALERT_KEYS,
 )
 from aas2rto.query_managers.fink.fink_portal_client import FinkZTFPortalClient
 from aas2rto.target import Target
@@ -32,6 +31,18 @@ logger = getLogger(__name__.split(".")[-1])
 
 ZTF_TARGET_ID_KEY = "objectId"
 ZTF_ALERT_ID_KEY = "candid"
+
+EXTRA_FINK_ZTF_ALERT_KEYS = (
+    # "timestamp", # doesn't exist anymore?!
+    "cdsxmatch",
+    "rf_snia_vs_nonia",
+    "snn_snia_vs_nonia",
+    "snn_sn_vs_all",
+    "mulens",
+    "roid",
+    "nalerthist",
+    "rf_kn_vs_nonkn",
+)
 
 
 class FinkZTFQueryManager(FinkBaseQueryManager):
@@ -157,9 +168,9 @@ def process_fink_ztf_alert(
     alert["tag"] = "valid"  # must be valid if it's arrived as an alert
     alert[ZTF_ALERT_ID_KEY] = alert_id  # the long ~20 digit ID number.
 
-    extra_data = {k: data[k] for k in EXTRA_FINK_ALERT_KEYS if k in data}
+    extra_data = {k: data[k] for k in EXTRA_FINK_ZTF_ALERT_KEYS if k in data}
     utils.check_missing_config_keys(
-        data, EXTRA_FINK_ALERT_KEYS, name=f"fink_ztf.{topic}.{fink_id}.{alert_id}"
+        data, EXTRA_FINK_ZTF_ALERT_KEYS, name=f"fink_ztf.{topic}.{fink_id}.{alert_id}"
     )
     alert.update(extra_data)
 

--- a/aas2rto/recovery/recovery_manager.py
+++ b/aas2rto/recovery/recovery_manager.py
@@ -155,6 +155,7 @@ class RecoveryManager:
             target_config = target_info.copy()
             ra = target_config.pop("ra")
             dec = target_config.pop("dec")
+            target_config["target_id"] = str(target_config["target_id"])  # FORCE str.
             target_config["coord"] = SkyCoord(ra=ra, dec=dec, unit="deg")
             target = Target(**target_config)
 

--- a/aas2rto/target_data.py
+++ b/aas2rto/target_data.py
@@ -38,7 +38,7 @@ class TargetData:
     def __init__(
         self,
         lightcurve: pd.DataFrame | Table = None,
-        include_badqual: bool = False,
+        # include_badqual: bool = False,
         # probabilities: pd.DataFrame | Table = None,
         parameters: dict = None,
         cutouts: dict = None,
@@ -92,7 +92,7 @@ class TargetData:
 
         if lightcurve is not None:
             self.add_lightcurve(
-                copy.deepcopy(lightcurve), include_badqual=include_badqual
+                copy.deepcopy(lightcurve),  # include_badqual=include_badqual
             )
         else:
             self.remove_lightcurve()  # set everything to None
@@ -153,12 +153,12 @@ class TargetData:
             # No need to be warn here - we are correctly setting the attributes!
             self.lightcurve = lightcurve
 
-        if include_badqual:
-            detection_tags = self.valid_tags + self.badqual_tags
-            badqual_tags = ()
-        else:
-            detection_tags = self.valid_tags
-            badqual_tags = self.badqual_tags
+        # if include_badqual:
+        #     detection_tags = self.valid_tags + self.badqual_tags
+        #     badqual_tags = ()
+        # else:
+        detection_tags = self.valid_tags
+        badqual_tags = self.badqual_tags
         nondet_tags = self.nondet_tags
         all_tags = detection_tags + badqual_tags + nondet_tags
         if tag_col in self.lightcurve.columns:

--- a/aas2rto/target_lookup.py
+++ b/aas2rto/target_lookup.py
@@ -62,7 +62,7 @@ class TargetLookup:
 
     def __setitem__(self, key: str, target: Target) -> None:
         if not isinstance(key, str):
-            logger.warning(f"type of key '{key}' should be 'str', not type={type(key)}")
+            logger.warning(f"key '{key}' should be 'str', not type={type(key)}")
         if not isinstance(target, Target):
             msg = f"new target {key} is type `{type(target)}`, not `aas2rto.target.Target`"
             raise NotATargetError(msg)
@@ -76,6 +76,8 @@ class TargetLookup:
         self.update_id_mapping_single_target(target)
 
     def __getitem__(self, key: str) -> Target:
+        if not isinstance(key, str):
+            logger.warning(f"key '{key}' should be 'str', not type='{type(key)}'")
         base_id = self.id_mapping.get(key, None)
         if base_id is None:
             raise KeyError(f"No target with name {key}")
@@ -88,6 +90,9 @@ class TargetLookup:
         else return the default value, which default=None.
 
         """
+        if not isinstance(target_id, str):
+            msg = f"key '{target_id}' should be 'str', not type='{type(target_id)}'"
+            logger.warning(msg)
         base_id = self.id_mapping.get(target_id, None)
         if base_id is None:
             return default

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -49,7 +49,7 @@ if __name__ == "__main__":
     lc_plotting_function = plot_default_lightcurve
     if "supernovae" in config_file.stem or "sne" in config_file.stem:
         scoring_function = SupernovaPeakScore(
-            use_compiled_lightcurve=True
+            use_compiled_lightcurve=True, faint_limit=23.0
         )  # This is a class - initialise it!
 
         models_path = None  # selector.path_manager.project_path / "sncosmo_salt_models"

--- a/test_aas2rto/conftest.py
+++ b/test_aas2rto/conftest.py
@@ -666,6 +666,7 @@ def fink_kafka_config():
         "group.id": 1234,
         "bootstrap.servers": "http://fink.blah.org",
         "topics": ["cool_sne"],
+        "survey": "cool_survey",
     }
 
 
@@ -683,6 +684,7 @@ def lasair_ztf_kafka_config():
         "topics": {
             "cool_sne": topic_keys,
         },
+        "survey": "ztf",
     }
 
 
@@ -700,6 +702,7 @@ def lasair_lsst_kafka_config():
         "topics": {
             "cool_sne": topic_keys,
         },
+        "survey": "lsst",
     }
 
 

--- a/test_aas2rto/unit/core/test__target_data.py
+++ b/test_aas2rto/unit/core/test__target_data.py
@@ -88,23 +88,23 @@ class Test__AddLightcurvePandas:
         assert len(tdata.non_detections) == 4
         assert np.isclose(tdata.non_detections["mjd"].iloc[0] - 60000.0, 0.0)
 
-    def test__det_with_badqual(self, tdata: TargetData, lc_pandas: pd.DataFrame):
-        # Act
-        tdata.add_lightcurve(lc_pandas, include_badqual=True)
+        # def test__det_with_badqual(self, tdata: TargetData, lc_pandas: pd.DataFrame):
+        #     # Act
+        #     tdata.add_lightcurve(lc_pandas, include_badqual=True)
 
-        # Assert
-        assert isinstance(tdata.lightcurve, pd.DataFrame)
-        assert len(tdata.lightcurve) == 14
+        #     # Assert
+        #     assert isinstance(tdata.lightcurve, pd.DataFrame)
+        #     assert len(tdata.lightcurve) == 14
 
-        assert isinstance(tdata.detections, pd.DataFrame)
-        assert len(tdata.detections) == 10
-        assert np.isclose(tdata.detections["mjd"].iloc[0] - 60000.0, 2.0)
+        #     assert isinstance(tdata.detections, pd.DataFrame)
+        #     assert len(tdata.detections) == 10
+        #     assert np.isclose(tdata.detections["mjd"].iloc[0] - 60000.0, 2.0)
 
-        assert isinstance(tdata.badqual, pd.DataFrame)
-        assert len(tdata.badqual) == 0
+        #     assert isinstance(tdata.badqual, pd.DataFrame)
+        #     assert len(tdata.badqual) == 0
 
-        assert isinstance(tdata.non_detections, pd.DataFrame)
-        assert len(tdata.non_detections) == 4
+        #     assert isinstance(tdata.non_detections, pd.DataFrame)
+        #     assert len(tdata.non_detections) == 4
         assert np.isclose(tdata.non_detections["mjd"].iloc[0] - 60000.0, 0.0)
 
     def test__new_tags(self, lc_pandas: pd.DataFrame):

--- a/test_aas2rto/unit/query_managers/fink/test__fink_lsst_qm.py
+++ b/test_aas2rto/unit/query_managers/fink/test__fink_lsst_qm.py
@@ -10,13 +10,14 @@ import pandas as pd
 from astropy import units as u
 from astropy.time import Time
 
-from aas2rto.query_managers.fink.fink_base import FinkAlert, EXTRA_FINK_ALERT_KEYS
+from aas2rto.query_managers.fink.fink_base import FinkAlert
 from aas2rto.query_managers.fink.fink_lsst import (
     FinkLSSTQueryManager,
     process_fink_lsst_alert,
     target_from_fink_lsst_alert,
     apply_fink_lsst_updates_to_target,
     process_fink_lsst_lightcurve,
+    EXTRA_FINK_LSST_ALERT_KEYS,
 )
 from aas2rto.target import Target
 from aas2rto.target_lookup import TargetLookup
@@ -129,7 +130,7 @@ class Test__ProcessLSSTAlert:
         cutout_keys = [f"cutout{x}" for x in "Science Difference Template".split()]
 
         assert all([k in proc_alert.keys() for k in candidate_keys])
-        assert all([k in proc_alert.keys() for k in EXTRA_FINK_ALERT_KEYS])  # copied
+        assert all([k in proc_alert.keys() for k in EXTRA_FINK_LSST_ALERT_KEYS])  # OK!
         # cutout removed before JSON!
         assert all([k not in proc_alert.keys() for k in cutout_keys])
 

--- a/test_aas2rto/unit/query_managers/fink/test__fink_ztf_qm.py
+++ b/test_aas2rto/unit/query_managers/fink/test__fink_ztf_qm.py
@@ -11,17 +11,14 @@ import pandas as pd
 from astropy import units as u
 from astropy.time import Time
 
-from aas2rto.query_managers.fink.fink_base import (
-    FinkBaseQueryManager,
-    FinkAlert,
-    EXTRA_FINK_ALERT_KEYS,
-)
+from aas2rto.query_managers.fink.fink_base import FinkBaseQueryManager, FinkAlert
 from aas2rto.query_managers.fink.fink_ztf import (
     FinkZTFQueryManager,
     process_fink_ztf_alert,
     target_from_fink_ztf_alert,
     process_fink_ztf_lightcurve,
     apply_fink_ztf_updates_to_target,
+    EXTRA_FINK_ZTF_ALERT_KEYS,
 )
 from aas2rto.target import Target
 from aas2rto.target_lookup import TargetLookup
@@ -110,7 +107,7 @@ class Test__ProcessZTFAlert:
         cutout_keys = [f"cutout{x}" for x in "Science Difference Template".split()]
 
         assert all([k in proc_alert.keys() for k in candidate_keys])
-        assert all([k in proc_alert.keys() for k in EXTRA_FINK_ALERT_KEYS])  # copied!
+        assert all([k in proc_alert.keys() for k in EXTRA_FINK_ZTF_ALERT_KEYS])  # OK!
         # cutout removed before JSON!
         assert all([k not in proc_alert.keys() for k in cutout_keys])
 


### PR DESCRIPTION
Modify FINK portal client now that official docs are available:
- methods common endpoints in base class
- methods for specific/unique endpoints in subclasses
- abstract method `query_lightcurve` and `query_classifiers` for base class, as correct endpoint varies between ZTF/FINK
- make sure targets from LSST have str `target_id`
    - more checks in target_lookup for `str` target_id
- typos