### PR TITLE
quickfix: fink_client AlertConsumer args

### DIFF
--- a/aas2rto/query_managers/fink/fink_base.py
+++ b/aas2rto/query_managers/fink/fink_base.py
@@ -311,11 +311,12 @@ class FinkBaseQueryManager(LightcurveQueryManager, KafkaQueryManager, abc.ABC):
 
         n_alerts = self.config["n_alerts"]
         timeout = self.config["alert_timeout"]
+        survey = self.kafka_config["survey"]
 
         alerts = []
         for topic in self.kafka_config["topics"]:
             topic_alerts = []
-            with AlertConsumer([topic], self.kafka_config) as consumer:
+            with AlertConsumer([topic], self.kafka_config, survey) as consumer:
                 logger.info(f"listen for up to {n_alerts} from {topic}")
                 for ii in range(n_alerts):
                     try:

--- a/aas2rto/target_lookup.py
+++ b/aas2rto/target_lookup.py
@@ -163,7 +163,7 @@ class TargetLookup:
                 to_modify[target_id] = target.target_id
 
         if len(to_modify) > 0:
-            logger.info("update target_id for {len(to_modify)} targets")
+            logger.info(f"update target_id for {len(to_modify)} targets")
         for old_id, new_id in to_modify.items():
             self.lookup[new_id] = self.lookup.pop(old_id)
 


### PR DESCRIPTION
quickfix: missing args for updated fink_client `AlertConsumer`; better test so that fink_client args are checked